### PR TITLE
65 disable automatic deployment to test

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,3 @@ on: [push]
 jobs:
   build:
     uses: ./.github/workflows/workflow-build.yaml
-    with:
-      # tag 'test' if merged to dev branch
-      publish: ${{ github.ref == 'refs/heads/dev' }}
-      tag-name: 'test'

--- a/.github/workflows/workflow-build.yaml
+++ b/.github/workflows/workflow-build.yaml
@@ -7,7 +7,7 @@ on:
         description: 'should the image be build'
         type: boolean
         default: false
-        required: true
+        required: false
       tag-name:
         description: 'image tag'
         required: false


### PR DESCRIPTION
**Description**

Disables automatic deployment to the 'test' environment upon merging into the 'dev' branch.

**Reference**

Issues #65 
