### PR TITLE
Fix user member in many active directory groups

### DIFF
--- a/src/main/java/de/muenchen/zammad/ad/ldap/mediator/ActiveDirectoryGroupZammadRoleMapper.java
+++ b/src/main/java/de/muenchen/zammad/ad/ldap/mediator/ActiveDirectoryGroupZammadRoleMapper.java
@@ -36,6 +36,8 @@ public class ActiveDirectoryGroupZammadRoleMapper {
     private final RequestedOrganizationalUnits requestedOuUnits;
     private final LdapService ldapService;
 
+    private Map<String, User> zammadUsers;
+
     @Autowired
     public ActiveDirectoryGroupZammadRoleMapper(LdapProperty ldapProperty, ZammadProperties zammadProperties, ActiveDirectoryProperty activeDirectoryProperties,
             ActiveDirectoryGroupService activeDirectoryGroupService, ZammadService zammadService,
@@ -63,7 +65,7 @@ public class ActiveDirectoryGroupZammadRoleMapper {
 
     public void syncAdGroupsToLdapRoles() {
 
-        Map<String, User> zammadUsers = zammadService.getZammadUsers().stream()
+        zammadUsers = zammadService.getZammadUsers().stream()
                 .filter(user -> user.getLhmobjectid() != null && !user.getLhmobjectid().isEmpty() && user.isLdapsyncupdate() && user.isActive())
                 .collect(Collectors.toMap(User::getLhmobjectid, user -> user));
 
@@ -144,6 +146,8 @@ public class ActiveDirectoryGroupZammadRoleMapper {
       var addedUser = zammadService.createZammadUser(newUser);
       log.debug("New user '{}' with zammad id '{}' added.", addedUser.getLhmobjectid(),
         addedUser.getId());
+      var shouldBeNull = Optional.ofNullable(zammadUsers.putIfAbsent(addedUser.getLhmobjectid(), addedUser));
+      shouldBeNull.ifPresent(user -> log.warn("User '{}' already exists.", user.getLhmobjectid()));
 
     }
 

--- a/src/main/java/de/muenchen/zammad/ldap/branch/OrgUnitBranchSynchronization.java
+++ b/src/main/java/de/muenchen/zammad/ldap/branch/OrgUnitBranchSynchronization.java
@@ -185,7 +185,7 @@ public class OrgUnitBranchSynchronization extends AbstractTree {
     private void updateUsers(User zammadUserCompare, List<User> users, String lhmObjectIdToFind) {
         if (users.size() > 1) {
           log.warn("Inconsistent Zammad state. More than one zammad group entry found for lhmObjectId '{}' :", lhmObjectIdToFind);
-                  users.forEach(item -> log.error(LOG_ID, item.getId()));
+                  users.forEach(item -> log.warn(LOG_ID, item.getId()));
         }
         users.forEach(user -> updateZammadUser(zammadUserCompare, lhmObjectIdToFind, user));
     }

--- a/src/main/java/de/muenchen/zammad/ldap/branch/OrgUnitBranchSynchronization.java
+++ b/src/main/java/de/muenchen/zammad/ldap/branch/OrgUnitBranchSynchronization.java
@@ -172,20 +172,8 @@ public class OrgUnitBranchSynchronization extends AbstractTree {
                 log.trace(zammadUserCompare.toString());
                 // Find zammad-user with lhmObjectID
                 String lhmObjectIdToFind = user.getLhmObjectId();
-                final var foundZammadUser = zammadUsersByLhmObjectId.get(lhmObjectIdToFind);
-                if (foundZammadUser != null && foundZammadUser.size() > 1) {
-                    log.error(
-                            "Inconsistent Zammad state. More than one zammad group entry found for lhmObjectId '{}' :",
-                            lhmObjectIdToFind);
-                    foundZammadUser.forEach(item -> log.error(LOG_ID, item.getId()));
-                } else if (foundZammadUser != null && foundZammadUser.size() == 1) {
-                    final var zammadLdapSyncUser = foundZammadUser.get(0);
-                    if (zammadLdapSyncUser != null) {
-                        updateZammadUser(zammadUserCompare, lhmObjectIdToFind, zammadLdapSyncUser);
-                    }
-                } else {
-                    createZammadUser(zammadUserCompare, lhmObjectIdToFind);
-                }
+                final var foundZammadUser = Optional.ofNullable(zammadUsersByLhmObjectId.get(lhmObjectIdToFind));
+                foundZammadUser.ifPresentOrElse(users ->  this.updateUsers(zammadUserCompare, users, lhmObjectIdToFind), () -> createZammadUser(zammadUserCompare, lhmObjectIdToFind));
                 log.debug(LOG_DIVIDER);
             });
 
@@ -193,6 +181,15 @@ public class OrgUnitBranchSynchronization extends AbstractTree {
             log.error(ex.getMessage(), ex);
         }
     }
+
+    private void updateUsers(User zammadUserCompare, List<User> users, String lhmObjectIdToFind) {
+        if (users.size() > 1) {
+          log.warn("Inconsistent Zammad state. More than one zammad group entry found for lhmObjectId '{}' :", lhmObjectIdToFind);
+                  users.forEach(item -> log.error(LOG_ID, item.getId()));
+        }
+        users.forEach(user -> updateZammadUser(zammadUserCompare, lhmObjectIdToFind, user));
+    }
+
 
     private void createZammadUser(User zammadUserCompare, String lhmObjectIdToFind) {
         log.debug("User not found in Zammad with lhmObjectid '{}' - creating.", lhmObjectIdToFind);

--- a/src/test/java/de/muenchen/zammad/ad/ldap/ActiveDirectoryGroupsTest.java
+++ b/src/test/java/de/muenchen/zammad/ad/ldap/ActiveDirectoryGroupsTest.java
@@ -56,7 +56,7 @@ class ActiveDirectoryGroupsTest extends PrepareTestCrossFunctionalGroups {
         mockUserLookUps(ldapService);
 
         var activeDirectoryGroupService = mock(ActiveDirectoryGroupService.class);
-        when(activeDirectoryGroupService.crossOrganizationalGroups()).thenReturn(Optional.of(createAndUpdateZammadRoles()));
+        when(activeDirectoryGroupService.crossOrganizationalGroups()).thenReturn(Optional.of(createAndUpdateZammadRolesEveryUserOnlyInOneRole()));
 
         var activeDirectoryRoleMapper = new ActiveDirectoryGroupZammadRoleMapper(ldapService, createZammadProperties(), new ActiveDirectoryProperty(null, null, null,null, "lhm-ab-dbsticketing-"), activeDirectoryGroupService, zammadService, new RequestedOrganizationalUnits(Map.of("ITM", new OrganizationalUnitProperties(null, LDAP_USER_SEARCH_BASE, null))));
         activeDirectoryRoleMapper.syncAdGroupsToLdapRoles();
@@ -118,7 +118,7 @@ class ActiveDirectoryGroupsTest extends PrepareTestCrossFunctionalGroups {
         mockUserLookUps(ldapService);
 
         var activeDirectoryGroupService = mock(ActiveDirectoryGroupService.class);
-        when(activeDirectoryGroupService.crossOrganizationalGroups()).thenReturn(Optional.of(createAndUpdateZammadRoles()));
+        when(activeDirectoryGroupService.crossOrganizationalGroups()).thenReturn(Optional.of(createAndUpdateZammadRolesEveryUserOnlyInOneRole()));
 
         var activeDirectoryRoleMapper = new ActiveDirectoryGroupZammadRoleMapper(ldapService, createZammadProperties(), new ActiveDirectoryProperty(null, null, null,null, "lhm-ab-dbsticketing-"), activeDirectoryGroupService, zammadService, new RequestedOrganizationalUnits(Map.of("ITM", new OrganizationalUnitProperties(null, LDAP_USER_SEARCH_BASE, null))));
         activeDirectoryRoleMapper.syncAdGroupsToLdapRoles();
@@ -152,6 +152,38 @@ class ActiveDirectoryGroupsTest extends PrepareTestCrossFunctionalGroups {
 
         verify(zammadService, times(0)).createZammadUser(createUserCaptor.capture());
         verify(zammadService, times(0)).updateZammadUser(updateUserCaptor.capture());
+    }
+
+    /*
+     * Add users not exist in ldap and are present in more than one active directory group.
+     */
+    @Test
+    void userExistsInManyActiveDirectoryGroups() {
+
+        var zammadService = mock(ZammadService.class);
+        when(zammadService.getZammadGroups()).thenReturn(List.of());
+        when(zammadService.getZammadRoles()).thenReturn(List.of(new Role(998, "rit-testrolle1-ig", null), new Role(999, "rit-testrolle2-ig", null)));
+        when(zammadService.getZammadUsers()).thenReturn(List.of(new User(2, "Tick", "Duck", "lhmObjectIdTickDuck", "ITM", "lhmObjectIdTickDuck", new ArrayList<Integer>(Arrays.asList(0,1,998)))));
+
+        mockZammadServiceActions(zammadService);
+
+        var ldapService = mock(LdapService.class);
+        mockUserLookUps(ldapService);
+
+        var activeDirectoryGroupService = mock(ActiveDirectoryGroupService.class);
+        when(activeDirectoryGroupService.crossOrganizationalGroups()).thenReturn(Optional.of(createAndUpdateZammadRolesUserInManyRoles()));
+
+        var activeDirectoryRoleMapper = new ActiveDirectoryGroupZammadRoleMapper(ldapService, createZammadProperties(), new ActiveDirectoryProperty(null, null, null,null, "lhm-ab-dbsticketing-"), activeDirectoryGroupService, zammadService, new RequestedOrganizationalUnits(Map.of("ITM", new OrganizationalUnitProperties(null, LDAP_USER_SEARCH_BASE, null))));
+        activeDirectoryRoleMapper.syncAdGroupsToLdapRoles();
+
+        verify(zammadService, times(2)).createZammadUser(createUserCaptor.capture());
+        var track = createUserCaptor.getAllValues().stream().filter(user -> user.getFirstname().equals("Track")).toList();
+        assertEquals("Track", track.get(0).getFirstname());
+        assertEquals(List.of(0,1,998), track.get(0).getRoleIds());
+        verify(zammadService, times(1)).updateZammadUser(updateUserCaptor.capture());
+        assertEquals("Track", updateUserCaptor.getAllValues().get(0).getFirstname());
+        assertEquals(List.of(0,1,998,999), updateUserCaptor.getAllValues().get(0).getRoleIds());
+
     }
 
 }

--- a/src/test/java/de/muenchen/zammad/ad/ldap/PrepareTestCrossFunctionalGroups.java
+++ b/src/test/java/de/muenchen/zammad/ad/ldap/PrepareTestCrossFunctionalGroups.java
@@ -2,6 +2,8 @@ package de.muenchen.zammad.ad.ldap;
 
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -19,7 +21,7 @@ public abstract class PrepareTestCrossFunctionalGroups extends PrepareZammadTest
 
     final Map<String, String> activeDirectoryUsers = Map.of("tick.duck", "CN=tick.duck,OU=d,OU=ITM,OU=c,DC=b,DC=a", "trick.duck", "CN=trick.duck,OU=kd,OU=ITM,OU=c,DC=b,DC=a", "track.duck", "CN=track.duck,OU=d,OU=ITM,OU=c,DC=bn,DC=a");
 
-    protected List<EnhancedActiveDirectoryGroupDTO> createAndUpdateZammadRoles() {
+    protected List<EnhancedActiveDirectoryGroupDTO> createAndUpdateZammadRolesEveryUserOnlyInOneRole() {
 
         return List.of(new EnhancedActiveDirectoryGroupDTO("lhm-ab-dbsticketing-rit-testrolle1-ig",
                 "lhm-ab-dbsticketing-rit-testrolle1-ig",
@@ -27,14 +29,46 @@ public abstract class PrepareTestCrossFunctionalGroups extends PrepareZammadTest
                 "lhm-ab-dbsticketing-rit-testrolle1-ig",
                 List.of(activeDirectoryUsers.get("tick.duck"),
                         activeDirectoryUsers.get("trick.duck")),
-                Map.of("lhmobjectId_2_1_1",
-                        new ActiveDirectoryUserDTO("trick.duck", "lhmobjectId_2_1_1",
+                Map.of("lhmObjectIdTrickDuck",
+                        new ActiveDirectoryUserDTO("trick.duck", "lhmObjectIdTrickDuck",
                                 activeDirectoryUsers.get("trick.duck"),
                                 "Trick Duck", "trick.duck", "trick.duck", "ITM"),
                         "lhmObjectIdTickDuck",
                         new ActiveDirectoryUserDTO("tick.duck", "lhmObjectIdTickDuck",
                                 activeDirectoryUsers.get("tick.duck"), "Tick Duck",
                                 "tick.duck", "tick.duck", "ITM"))),
+                new EnhancedActiveDirectoryGroupDTO("lhm-ab-dbsticketing-rit-testrolle2-ig",
+                        "lhm-ab-dbsticketing-rit-testrolle2-ig",
+                        "CN=lhm-ab-dbsticketing-rit-testrolle2-ig,OU=f,OU=d,OU=c,DC=b,DC=a",
+                        "lhm-ab-dbsticketing-rit-testrolle2-ig",
+                        List.of(activeDirectoryUsers.get("track.duck")),
+                        Map.of("lhmObjectIdTrackDuck",
+                                new ActiveDirectoryUserDTO("track.duck", "lhmObjectIdTrackDuck",
+                                        activeDirectoryUsers.get("track.duck"),
+                                        "Track Duck", "track.duck", "track.duck", "ITM"))));
+    }
+
+    protected List<EnhancedActiveDirectoryGroupDTO> createAndUpdateZammadRolesUserInManyRoles() {
+
+        return List.of(new EnhancedActiveDirectoryGroupDTO("lhm-ab-dbsticketing-rit-testrolle1-ig",
+                "lhm-ab-dbsticketing-rit-testrolle1-ig",
+                "CN=lhm-ab-dbsticketing-rit-testrolle1-ig,OU=f,OU=d,OU=c,DC=b,DC=a",
+                "lhm-ab-dbsticketing-rit-testrolle1-ig",
+                List.of(activeDirectoryUsers.get("tick.duck"),
+                        activeDirectoryUsers.get("trick.duck"),
+                        activeDirectoryUsers.get("track.duck")),
+                Map.of("lhmObjectIdTrickDuck",
+                        new ActiveDirectoryUserDTO("trick.duck", "lhmObjectIdTrickDuck",
+                                activeDirectoryUsers.get("trick.duck"),
+                                "Trick Duck", "trick.duck", "trick.duck", "ITM"),
+                        "lhmObjectIdTickDuck",
+                        new ActiveDirectoryUserDTO("tick.duck", "lhmObjectIdTickDuck",
+                                activeDirectoryUsers.get("tick.duck"), "Tick Duck",
+                                "tick.duck", "tick.duck", "ITM"),
+                        "lhmObjectIdTrackDuck",
+                        new ActiveDirectoryUserDTO("track.duck", "lhmObjectIdTrackDuck",
+                                activeDirectoryUsers.get("track.duck"),
+                                "Track Duck", "track.duck", "track.duck", "ITM"))),
                 new EnhancedActiveDirectoryGroupDTO("lhm-ab-dbsticketing-rit-testrolle2-ig",
                         "lhm-ab-dbsticketing-rit-testrolle2-ig",
                         "CN=lhm-ab-dbsticketing-rit-testrolle2-ig,OU=f,OU=d,OU=c,DC=b,DC=a",
@@ -53,8 +87,8 @@ public abstract class PrepareTestCrossFunctionalGroups extends PrepareZammadTest
                 "CN=lhm-ab-dbsticketing-rit-testrolle1-ig,OU=f,OU=d,OU=c,DC=b,DC=a",
                 "lhm-ab-dbsticketing-rit-testrolle1-ig",
                 List.of(activeDirectoryUsers.get("trick.duck")),
-                Map.of("lhmobjectId_2_1_1",
-                        new ActiveDirectoryUserDTO("trick.duck", "lhmobjectId_2_1_1",
+                Map.of("lhmObjectIdTrickDuck",
+                        new ActiveDirectoryUserDTO("trick.duck", "lhmObjectIdTrickDuck",
                                 activeDirectoryUsers.get("trick.duck"),
                                 "Trick Duck", "trick.duck", "trick.duck", "ITM"))),
         new EnhancedActiveDirectoryGroupDTO("lhm-ab-dbsticketing-rit-testrolle2-ig",
@@ -75,10 +109,13 @@ public abstract class PrepareTestCrossFunctionalGroups extends PrepareZammadTest
 
     protected void mockZammadServiceActions(ZammadService zammadService) {
 
-        when(zammadService.createZammadUser(new User(null, "Trick", "Duck", "lhmObjectIdTrickDuck", true, null, null, "lhmObjectIdTrickDuck", List.of(0, 1, 998), null, null, true, null))).thenReturn(new User(1, "Trick", "Duck", "lhmObjectIdTrickDuck", true, null, null, "lhmObjectIdTrickDuck", List.of(0, 1, 998), null, null, true, null));
+        when(zammadService.createZammadUser(new User(null, "Trick", "Duck", "lhmObjectIdTrickDuck", true, null, null, "lhmObjectIdTrickDuck", new ArrayList<Integer>(Arrays.asList(0, 1, 998)), null, null, true, null))).thenReturn(new User(1, "Trick", "Duck", "lhmObjectIdTrickDuck", true, null, null, "lhmObjectIdTrickDuck", new ArrayList<Integer>(Arrays.asList(0, 1, 998)), null, null, true, null));
+        when(zammadService.createZammadUser(new User(null, "Track", "Duck", "lhmObjectIdTrackDuck", true, null, null, "lhmObjectIdTrackDuck", new ArrayList<Integer>(Arrays.asList(0, 1, 998)), null, null, true, null))).thenReturn(new User(3, "Track", "Duck", "lhmObjectIdTrackDuck", true, null, null, "lhmObjectIdTrackDuck", new ArrayList<Integer>(Arrays.asList(0, 1, 998)), null, null, true, null));
 
-        when(zammadService.updateZammadUser(new User(2, "Tick", "Duck", "lhmObjectIdTickDuck", false, null, "ITM", "lhmObjectIdTickDuck", List.of(0, 1), null, null, false, null))).thenReturn(new User(2, "Tick", "Duck", "lhmObjectIdTickDuck", false, null, "ITM", "lhmObjectIdTickDuck", List.of(0, 1), null, null, false, null));
-        when(zammadService.updateZammadUser(new User(3, "Track", "Duck", "lhmObjectIdTrackDuck", false, null, "ITM", "lhmObjectIdTrackDuck", List.of(0, 1), null, null, false, null))).thenReturn(new User(3, "Track", "Duck", "lhmObjectIdTrackDuck", false, null, "ITM", "lhmObjectIdTrackDuck", List.of(0, 1), null, null, false, null));
+        when(zammadService.updateZammadUser(new User(2, "Tick", "Duck", "lhmObjectIdTickDuck", false, null, "ITM", "lhmObjectIdTickDuck", new ArrayList<Integer>(Arrays.asList(0, 1)), null, null, false, null))).thenReturn(new User(2, "Tick", "Duck", "lhmObjectIdTickDuck", false, null, "ITM", "lhmObjectIdTickDuck", new ArrayList<Integer>(Arrays.asList(0, 1)), null, null, false, null));
+        when(zammadService.updateZammadUser(new User(3, "Track", "Duck", "lhmObjectIdTrackDuck", false, null, "ITM", "lhmObjectIdTrackDuck", new ArrayList<Integer>(Arrays.asList(0, 1)), null, null, false, null))).thenReturn(new User(3, "Track", "Duck", "lhmObjectIdTrackDuck", false, null, "ITM", "lhmObjectIdTrackDuck", new ArrayList<Integer>(Arrays.asList(0, 1)), null, null, false, null));
+        when(zammadService.updateZammadUser(new User(3, "Track", "Duck", "lhmObjectIdTrackDuck", false, null, "ITM", "lhmObjectIdTrackDuck", new ArrayList<Integer>(Arrays.asList(0, 1, 998, 999)), null, null, true, null))).thenReturn(new User(3, "Track", "Duck", "lhmObjectIdTrackDuck", false, null, "ITM", "lhmObjectIdTrackDuck", new ArrayList<Integer>(Arrays.asList(0, 1, 998, 999)), null, null, true, null));
+
     }
 
 }


### PR DESCRIPTION
**Description**
Handle users exists in many active directory groups.
Update all zammad accounts with same lhmobjectid.

Short description or comments

**Reference**
none

Issues: none
