### PR TITLE
Issue 31 snow incident heiratsbuero

### DIFF
--- a/src/main/java/de/muenchen/zammad/ad/ActiveDirectoryUserAttributesMapper.java
+++ b/src/main/java/de/muenchen/zammad/ad/ActiveDirectoryUserAttributesMapper.java
@@ -18,9 +18,12 @@ public class ActiveDirectoryUserAttributesMapper implements AttributesMapper<Act
         user.setDisplayName(safelyGet("displayName", attributes));
         user.setDistinguishedName(safelyGet("distinguishedName", attributes));
         user.setName(safelyGet("name", attributes));
+        user.setGivenName(safelyGet("givenName", attributes));
+        user.setSn(safelyGet("sn", attributes));
         user.setLhmObjectId(safelyGet("lhmObjectID", attributes));
         user.setUid(safelyGet("uid", attributes));
-        user.setLhmReferatName(user.getDistinguishedName().split(",")[2].split("=")[1]);
+        user.setMail(safelyGet("mail", attributes));
+        user.setOu(safelyGet("department", attributes));
 
         return user;
     }

--- a/src/main/java/de/muenchen/zammad/ad/ActiveDirectoryUserDTO.java
+++ b/src/main/java/de/muenchen/zammad/ad/ActiveDirectoryUserDTO.java
@@ -24,6 +24,9 @@ public class ActiveDirectoryUserDTO implements Serializable{
     private String displayName;
     private String name;
     private String uid;
-    private String lhmReferatName;
+    private String givenName;
+    private String sn;
+    private String mail;
+    private String ou;
 
 }

--- a/src/main/java/de/muenchen/zammad/ad/ldap/mediator/ActiveDirectoryGroupZammadRoleMapper.java
+++ b/src/main/java/de/muenchen/zammad/ad/ldap/mediator/ActiveDirectoryGroupZammadRoleMapper.java
@@ -5,12 +5,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import de.muenchen.oss.ezldap.core.EnhancedLdapUserDTO;
-import de.muenchen.oss.ezldap.core.LdapUserDTO;
-import de.muenchen.userservice.LdapService;
+import de.muenchen.userservice.ActiveDirectoryService;
 import de.muenchen.zammad.ad.ActiveDirectoryGroupService;
 import de.muenchen.zammad.ad.ActiveDirectoryUserDTO;
 import de.muenchen.zammad.ad.EnhancedActiveDirectoryGroupDTO;
@@ -20,8 +17,6 @@ import de.muenchen.zammad.ldap.branch.OrgUnitBranchSynchronization;
 import de.muenchen.zammad.ldap.branch.SimpleZammadUserFactory;
 import de.muenchen.zammad.ldap.branch.ZammadService;
 import de.muenchen.zammad.property.ActiveDirectoryProperty;
-import de.muenchen.zammad.property.LdapProperty;
-import de.muenchen.zammad.property.RequestedOrganizationalUnits;
 import de.muenchen.zammad.property.ZammadProperties;
 import lombok.extern.slf4j.Slf4j;
 
@@ -33,33 +28,16 @@ public class ActiveDirectoryGroupZammadRoleMapper {
     private final ZammadService zammadService;
     private final ZammadProperties zammadProperties;
     private final ActiveDirectoryProperty activeDirectoryProperties;
-
-    private final RequestedOrganizationalUnits requestedOuUnits;
-    private final LdapService ldapService;
-
+    private final ActiveDirectoryService adService;
     private Map<String, List<User>> zammadUsers;
 
-    @Autowired
-    public ActiveDirectoryGroupZammadRoleMapper(LdapProperty ldapProperty, ZammadProperties zammadProperties, ActiveDirectoryProperty activeDirectoryProperties,
-            ActiveDirectoryGroupService activeDirectoryGroupService, ZammadService zammadService,
-            RequestedOrganizationalUnits requestedOuUnits) {
-        super();
-        this.ldapService = new LdapService(ldapProperty.getUrl(), null, null, null, null);
-        this.activeDirectoryGroupService = activeDirectoryGroupService;
-        this.zammadService = zammadService;
-        this.requestedOuUnits = requestedOuUnits;
-        this.zammadProperties = zammadProperties;
-        this.activeDirectoryProperties = activeDirectoryProperties;
-    }
+   public ActiveDirectoryGroupZammadRoleMapper(ActiveDirectoryService adService, ZammadProperties zammadProperties, ActiveDirectoryProperty activeDirectoryProperties,
+            ActiveDirectoryGroupService activeDirectoryGroupService, ZammadService zammadService) {
 
-   public ActiveDirectoryGroupZammadRoleMapper(LdapService ldapService, ZammadProperties zammadProperties, ActiveDirectoryProperty activeDirectoryProperties,
-            ActiveDirectoryGroupService activeDirectoryGroupService, ZammadService zammadService,
-            RequestedOrganizationalUnits requestedOuUnits) {
         super();
-        this.ldapService = ldapService;
+        this.adService = adService;
         this.activeDirectoryGroupService = activeDirectoryGroupService;
         this.zammadService = zammadService;
-        this.requestedOuUnits = requestedOuUnits;
         this.zammadProperties = zammadProperties;
         this.activeDirectoryProperties = activeDirectoryProperties;
     }
@@ -88,16 +66,15 @@ public class ActiveDirectoryGroupZammadRoleMapper {
 
                         log.info("Processing role name '{}' with zammad id '{}' ... ", role.getName(), roleId);
 
-                        List<EnhancedLdapUserDTO> activeDirectoryLdapUsers = lookupLdapUsers(
-                                adGroup.getAdUserByLhmObjectId());
+                        List<ActiveDirectoryUserDTO> activeDirectoryUsers = adGroup.getAdUserByLhmObjectId().values().stream().map(user -> adService.lookupUser(user.getDistinguishedName())).toList();
 
-                        log.debug("'{}' Users found in role name '{}' with zammad id '{}'.", activeDirectoryLdapUsers.size(), role.getName(), roleId);
+                        log.debug("'{}' Users found in role name '{}' with zammad id '{}'.", activeDirectoryUsers.size(), role.getName(), roleId);
 
-                        activeDirectoryLdapUsers.forEach(activeDirectoryLdapUser -> {
+                        activeDirectoryUsers.forEach(activeDirectoryUser -> {
 
                             Optional<List<User>> currentUser = Optional
-                                    .ofNullable(zammadUsers.get(activeDirectoryLdapUser.getLhmObjectId()));
-                            currentUser.ifPresentOrElse(users -> this.updateUser(users, roleId), () -> newUser(activeDirectoryLdapUser, roleId));
+                                    .ofNullable(zammadUsers.get(activeDirectoryUser.getLhmObjectId()));
+                            currentUser.ifPresentOrElse(users -> this.updateUser(users, roleId), () -> newUser(activeDirectoryUser, roleId));
                         });
 
                         zammadUsers.values().forEach(users -> removeUserRoleId(users, adGroup, roleId));
@@ -138,11 +115,11 @@ public class ActiveDirectoryGroupZammadRoleMapper {
         });
     }
 
-    private void newUser(LdapUserDTO activeDirectoryLdapUser, Integer roleId) {
+    private void newUser(ActiveDirectoryUserDTO activeDirectoryUser, Integer roleId) {
 
       SimpleZammadUserFactory simpleBuilder = new SimpleZammadUserFactory(
               this.zammadProperties);
-      var newUser = simpleBuilder.mapToZammadUser(activeDirectoryLdapUser, Optional.empty());
+      var newUser = simpleBuilder.mapToZammadUser(activeDirectoryUser, Optional.empty());
       newUser.getRoleIds().add(roleId);
       SimpleZammadUserFactory.activate(newUser);
       var addedUser = zammadService.createZammadUser(newUser);
@@ -157,24 +134,5 @@ public class ActiveDirectoryGroupZammadRoleMapper {
         return activeDirectoryProperties.getGroupNamePrefix() != null ? activeDirectoryProperties.getGroupNamePrefix() : "";
     }
 
-    private List<EnhancedLdapUserDTO> lookupLdapUsers(Map<String, ActiveDirectoryUserDTO> adUserByLhmObjectId) {
-        return adUserByLhmObjectId.entrySet().stream().filter(entry -> investigateLdapUserDn(entry.getValue()) != null)
-                .map(entry -> ldapService.lookupUser(investigateLdapUserDn(entry.getValue())).get()).toList();
-    }
-
-    /*
-     * Determine the ldap search base using the department abbreviation in the
-     * configuration, add uid and return complete ldap user distinguished name. This
-     * assumes that the OU identifiers in the configuration correspond to the
-     * department AD identifiers.
-     */
-    private String investigateLdapUserDn(ActiveDirectoryUserDTO user) {
-        var propertiesOuAbbrevationExists = Optional.ofNullable(requestedOuUnits.getOrganizationalUnits().get(user.getLhmReferatName().toUpperCase()));
-        if (propertiesOuAbbrevationExists.isPresent())
-            return String.join(",", "uid=" + user.getUid(), propertiesOuAbbrevationExists.get().getUserSearchBase());
-        else {
-            log.warn("Organizational unit abbrevation '{}' of active directory user ('lhmObjectId={}') contained in 'distinguished name' attribute of the user is not configured in application properties. The active directory user is not synced with 'zammad role authorization'.", user.getLhmReferatName(), user.getLhmObjectId());
-            return null;}
-    }
 
 }

--- a/src/main/java/de/muenchen/zammad/ad/ldap/mediator/ActiveDirectoryGroupZammadRoleMapper.java
+++ b/src/main/java/de/muenchen/zammad/ad/ldap/mediator/ActiveDirectoryGroupZammadRoleMapper.java
@@ -48,8 +48,7 @@ public class ActiveDirectoryGroupZammadRoleMapper {
         zammadUsers = OrgUnitBranchSynchronization.generatelhmObjectIdZammadUserMap(zammadService.getZammadCache().flatMapUsersByLhmObjectId());
 
         log.info("Start active directory user lookup ...");
-        Optional<List<EnhancedActiveDirectoryGroupDTO>> adGroups = activeDirectoryGroupService
-                .crossOrganizationalGroups();
+        Optional<List<EnhancedActiveDirectoryGroupDTO>> adGroups = activeDirectoryGroupService.crossOrganizationalGroups();
         log.info("End active directory user lookup.");
 
         Map<String, Role> zammadRoles = zammadService.getZammadRoles().stream().collect(
@@ -128,7 +127,7 @@ public class ActiveDirectoryGroupZammadRoleMapper {
                 }
             }
             else {
-                log.warn("User with zammad id {} and roleId {} : ldapsyncupdate = false, skip update. ", user.getId(), roleId);
+                log.warn("User with zammad id {} (lhmobjectid={}) and roleId {} : ldapsyncupdate = false, skip update. ", user.getId(), user.getLhmobjectid(), roleId);
             }
         });
 

--- a/src/main/java/de/muenchen/zammad/ad/ldap/mediator/ActiveDirectoryGroupZammadRoleMapper.java
+++ b/src/main/java/de/muenchen/zammad/ad/ldap/mediator/ActiveDirectoryGroupZammadRoleMapper.java
@@ -46,8 +46,10 @@ public class ActiveDirectoryGroupZammadRoleMapper {
 
         zammadUsers = OrgUnitBranchSynchronization.generatelhmObjectIdZammadUserMap(zammadService.getZammadCache().flatMapUsersByLhmObjectId().stream().filter(user -> user.isLdapsyncupdate()).toList());
 
+        log.info("Start active directory user lookup ...");
         Optional<List<EnhancedActiveDirectoryGroupDTO>> adGroups = activeDirectoryGroupService
                 .crossOrganizationalGroups();
+        log.info("End active directory user lookup.");
 
         Map<String, Role> zammadRoles = zammadService.getZammadRoles().stream()
                 .collect(Collectors.toMap(role -> role.getName().replace(groupNamePrefixNullCheck(), ""), role -> role));
@@ -110,7 +112,7 @@ public class ActiveDirectoryGroupZammadRoleMapper {
                 }
                 if (!user.isActive()) {
                     user.setActive(true);
-                    user.setLdapsyncstate("");
+                    user.setLdapsyncstate(null);
                     log.debug("Reactivate User (active=true, ldapsyncstate='') '{}' with zammad id '{}'.", user.getLhmobjectid(), user.getId());
                 }
                 zammadService.updateZammadUser(user);

--- a/src/main/java/de/muenchen/zammad/ad/ldap/mediator/ActiveDirectoryGroupZammadRoleMapper.java
+++ b/src/main/java/de/muenchen/zammad/ad/ldap/mediator/ActiveDirectoryGroupZammadRoleMapper.java
@@ -44,8 +44,7 @@ public class ActiveDirectoryGroupZammadRoleMapper {
 
     public void syncAdGroupsToLdapRoles() {
 
-        zammadUsers = OrgUnitBranchSynchronization.generatelhmObjectIdZammadUserMap(zammadService.getZammadUsers().stream()
-                .filter(user -> user.isLdapsyncupdate() && user.isActive()).toList());
+        zammadUsers = OrgUnitBranchSynchronization.generatelhmObjectIdZammadUserMap(zammadService.getZammadCache().flatMapUsersByLhmObjectId().stream().filter(user -> user.isLdapsyncupdate() && user.isActive()).toList());
 
         Optional<List<EnhancedActiveDirectoryGroupDTO>> adGroups = activeDirectoryGroupService
                 .crossOrganizationalGroups();

--- a/src/main/java/de/muenchen/zammad/ad/ldap/mediator/ActiveDirectoryGroupZammadRoleMapper.java
+++ b/src/main/java/de/muenchen/zammad/ad/ldap/mediator/ActiveDirectoryGroupZammadRoleMapper.java
@@ -44,7 +44,7 @@ public class ActiveDirectoryGroupZammadRoleMapper {
 
     public void syncAdGroupsToLdapRoles() {
 
-        zammadUsers = OrgUnitBranchSynchronization.generatelhmObjectIdZammadUserMap(zammadService.getZammadCache().flatMapUsersByLhmObjectId().stream().filter(user -> user.isLdapsyncupdate() && user.isActive()).toList());
+        zammadUsers = OrgUnitBranchSynchronization.generatelhmObjectIdZammadUserMap(zammadService.getZammadCache().flatMapUsersByLhmObjectId().stream().filter(user -> user.isLdapsyncupdate()).toList());
 
         Optional<List<EnhancedActiveDirectoryGroupDTO>> adGroups = activeDirectoryGroupService
                 .crossOrganizationalGroups();
@@ -71,9 +71,9 @@ public class ActiveDirectoryGroupZammadRoleMapper {
 
                         activeDirectoryUsers.forEach(activeDirectoryUser -> {
 
-                            Optional<List<User>> currentUser = Optional
+                            Optional<List<User>> zammadUser = Optional
                                     .ofNullable(zammadUsers.get(activeDirectoryUser.getLhmObjectId()));
-                            currentUser.ifPresentOrElse(users -> this.updateUser(users, roleId), () -> newUser(activeDirectoryUser, roleId));
+                            zammadUser.ifPresentOrElse(users -> this.updateUser(users, roleId), () -> this.newUser(activeDirectoryUser, roleId));
                         });
 
                         zammadUsers.values().forEach(users -> removeUserRoleId(users, adGroup, roleId));
@@ -102,11 +102,18 @@ public class ActiveDirectoryGroupZammadRoleMapper {
 
     private void updateUser(List<User> users, Integer roleId) {
         users.forEach(user -> {
-            if (!user.getRoleIds().contains(roleId)) {
-                user.getRoleIds().add(roleId);
+            if (!user.getRoleIds().contains(roleId) || !user.isActive()) {
+                if (!user.getRoleIds().contains(roleId)) {
+                    user.getRoleIds().add(roleId);
+                    log.debug("User '{}' with zammad id '{}' roleIds '{}' updated.", user.getLhmobjectid(), user.getId(),
+                            user.getRoleIds().toString());
+                }
+                if (!user.isActive()) {
+                    user.setActive(true);
+                    user.setLdapsyncstate("");
+                    log.debug("Reactivate User (active=true, ldapsyncstate='') '{}' with zammad id '{}'.", user.getLhmobjectid(), user.getId());
+                }
                 zammadService.updateZammadUser(user);
-                log.debug("User '{}' with zammad id '{}' roleIds '{}' updated.", user.getLhmobjectid(), user.getId(),
-                        user.getRoleIds().toString());
             } else {
                 log.debug("User '{}' with zammad id '{}' already has roleIds '{}' ({}).", user.getLhmobjectid(),
                         user.getId(), roleId, user.getRoleIds().toString());

--- a/src/main/java/de/muenchen/zammad/ad/ldap/mediator/ActiveDirectoryGroupZammadRoleMapper.java
+++ b/src/main/java/de/muenchen/zammad/ad/ldap/mediator/ActiveDirectoryGroupZammadRoleMapper.java
@@ -31,8 +31,9 @@ public class ActiveDirectoryGroupZammadRoleMapper {
     private final ActiveDirectoryService adService;
     private Map<String, List<User>> zammadUsers;
 
-   public ActiveDirectoryGroupZammadRoleMapper(ActiveDirectoryService adService, ZammadProperties zammadProperties, ActiveDirectoryProperty activeDirectoryProperties,
-            ActiveDirectoryGroupService activeDirectoryGroupService, ZammadService zammadService) {
+    public ActiveDirectoryGroupZammadRoleMapper(ActiveDirectoryService adService, ZammadProperties zammadProperties,
+            ActiveDirectoryProperty activeDirectoryProperties, ActiveDirectoryGroupService activeDirectoryGroupService,
+            ZammadService zammadService) {
 
         super();
         this.adService = adService;
@@ -44,21 +45,22 @@ public class ActiveDirectoryGroupZammadRoleMapper {
 
     public void syncAdGroupsToLdapRoles() {
 
-        zammadUsers = OrgUnitBranchSynchronization.generatelhmObjectIdZammadUserMap(zammadService.getZammadCache().flatMapUsersByLhmObjectId().stream().filter(user -> user.isLdapsyncupdate()).toList());
+        zammadUsers = OrgUnitBranchSynchronization.generatelhmObjectIdZammadUserMap(zammadService.getZammadCache().flatMapUsersByLhmObjectId());
 
         log.info("Start active directory user lookup ...");
         Optional<List<EnhancedActiveDirectoryGroupDTO>> adGroups = activeDirectoryGroupService
                 .crossOrganizationalGroups();
         log.info("End active directory user lookup.");
 
-        Map<String, Role> zammadRoles = zammadService.getZammadRoles().stream()
-                .collect(Collectors.toMap(role -> role.getName().replace(groupNamePrefixNullCheck(), ""), role -> role));
+        Map<String, Role> zammadRoles = zammadService.getZammadRoles().stream().collect(
+                Collectors.toMap(role -> role.getName().replace(groupNamePrefixNullCheck(), ""), role -> role));
 
         adGroups.ifPresent(activeDirectoryGroups -> {
 
             for (EnhancedActiveDirectoryGroupDTO adGroup : activeDirectoryGroups) {
 
-                var zammadRole = Optional.ofNullable(zammadRoles.get(adGroup.getName().replace(groupNamePrefixNullCheck(), "")));
+                var zammadRole = Optional
+                        .ofNullable(zammadRoles.get(adGroup.getName().replace(groupNamePrefixNullCheck(), "")));
                 zammadRole.ifPresentOrElse(role -> {
 
                     var zammadRoleId = Optional.of(role.getId());
@@ -67,34 +69,36 @@ public class ActiveDirectoryGroupZammadRoleMapper {
 
                         log.info("Processing role name '{}' with zammad id '{}' ... ", role.getName(), roleId);
 
-                        List<ActiveDirectoryUserDTO> activeDirectoryUsers = adGroup.getAdUserByLhmObjectId().values().stream().map(user -> adService.lookupUser(user.getDistinguishedName())).toList();
+                        List<ActiveDirectoryUserDTO> activeDirectoryUsers = adGroup.getAdUserByLhmObjectId().values()
+                                .stream().map(user -> adService.lookupUser(user.getDistinguishedName())).toList();
 
-                        log.debug("'{}' Users found in role name '{}' with zammad id '{}'.", activeDirectoryUsers.size(), role.getName(), roleId);
+                        log.debug("'{}' Users found in role name '{}' with zammad id '{}'.",
+                                activeDirectoryUsers.size(), role.getName(), roleId);
 
                         activeDirectoryUsers.forEach(activeDirectoryUser -> {
 
                             Optional<List<User>> zammadUser = Optional
                                     .ofNullable(zammadUsers.get(activeDirectoryUser.getLhmObjectId()));
-                            zammadUser.ifPresentOrElse(users -> this.updateUser(users, roleId), () -> this.newUser(activeDirectoryUser, roleId));
+                            zammadUser.ifPresentOrElse(users -> this.updateUser(users, roleId),
+                                    () -> this.newUser(activeDirectoryUser, roleId));
                         });
 
                         zammadUsers.values().forEach(users -> removeUserRoleId(users, adGroup, roleId));
 
                     });
-                }, () -> log.warn("Active directory group/role '{}' not found in current zammad instance. The search applies 'group-name-pefix' : '{}'.",
-                        adGroup.getName().replace(activeDirectoryProperties.getGroupNamePrefix(), ""), activeDirectoryProperties.getGroupNamePrefix()));
+                }, () -> log.warn(
+                        "Active directory group/role '{}' not found in current zammad instance. The search applies 'group-name-pefix' : '{}'.",
+                        adGroup.getName().replace(activeDirectoryProperties.getGroupNamePrefix(), ""),
+                        activeDirectoryProperties.getGroupNamePrefix()));
             }
         });
     }
 
-    protected void removeUserRoleId(List<User> zammadUsers, EnhancedActiveDirectoryGroupDTO adGroup,
-            Integer roleId) {
+    protected void removeUserRoleId(List<User> zammadUsers, EnhancedActiveDirectoryGroupDTO adGroup, Integer roleId) {
 
-        var zammadUsersWithRoleId = zammadUsers.stream()
-                .filter(user -> user.getRoleIds().contains(roleId)).toList();
+        var zammadUsersWithRoleId = zammadUsers.stream().filter(user -> user.getRoleIds().contains(roleId)).toList();
         var removeRoleIdFromUsers = zammadUsersWithRoleId.stream()
-                .filter(user -> adGroup.getAdUserByLhmObjectId().get(user.getLhmobjectid()) == null)
-                .toList();
+                .filter(user -> adGroup.getAdUserByLhmObjectId().get(user.getLhmobjectid()) == null).toList();
         removeRoleIdFromUsers.forEach(user -> {
             user.getRoleIds().remove(roleId);
             var updatedUser = zammadService.updateZammadUser(user);
@@ -104,43 +108,49 @@ public class ActiveDirectoryGroupZammadRoleMapper {
 
     private void updateUser(List<User> users, Integer roleId) {
         users.forEach(user -> {
-            if (!user.getRoleIds().contains(roleId) || !user.isActive()) {
-                if (!user.getRoleIds().contains(roleId)) {
-                    user.getRoleIds().add(roleId);
-                    log.debug("User '{}' with zammad id '{}' roleIds '{}' updated.", user.getLhmobjectid(), user.getId(),
-                            user.getRoleIds().toString());
+            if (user.isLdapsyncupdate()) {
+                if (!user.getRoleIds().contains(roleId) || !user.isActive()) {
+                    if (!user.getRoleIds().contains(roleId)) {
+                        user.getRoleIds().add(roleId);
+                        log.debug("User '{}' with zammad id '{}' roleIds '{}' updated.", user.getLhmobjectid(),
+                                user.getId(), user.getRoleIds().toString());
+                    }
+                    if (!user.isActive()) {
+                        user.setActive(true);
+                        user.setLdapsyncstate(null);
+                        log.debug("Reactivate User (active=true, ldapsyncstate='') '{}' with zammad id '{}'.",
+                                user.getLhmobjectid(), user.getId());
+                    }
+                    zammadService.updateZammadUser(user);
+                } else {
+                    log.debug("User '{}' with zammad id '{}' already has roleIds '{}' ({}).", user.getLhmobjectid(),
+                            user.getId(), roleId, user.getRoleIds().toString());
                 }
-                if (!user.isActive()) {
-                    user.setActive(true);
-                    user.setLdapsyncstate(null);
-                    log.debug("Reactivate User (active=true, ldapsyncstate='') '{}' with zammad id '{}'.", user.getLhmobjectid(), user.getId());
-                }
-                zammadService.updateZammadUser(user);
-            } else {
-                log.debug("User '{}' with zammad id '{}' already has roleIds '{}' ({}).", user.getLhmobjectid(),
-                        user.getId(), roleId, user.getRoleIds().toString());
+            }
+            else {
+                log.warn("User with zammad id {} and roleId {} : ldapsyncupdate = false, skip update. ", user.getId(), roleId);
             }
         });
+
     }
 
     private void newUser(ActiveDirectoryUserDTO activeDirectoryUser, Integer roleId) {
 
-      SimpleZammadUserFactory simpleBuilder = new SimpleZammadUserFactory(
-              this.zammadProperties);
-      var newUser = simpleBuilder.mapToZammadUser(activeDirectoryUser, Optional.empty());
-      newUser.getRoleIds().add(roleId);
-      SimpleZammadUserFactory.activate(newUser);
-      var addedUser = zammadService.createZammadUser(newUser);
-      log.debug("New user '{}' with zammad id '{}' added.", addedUser.getLhmobjectid(),
-        addedUser.getId());
-      var shouldBeNull = Optional.ofNullable(zammadUsers.putIfAbsent(addedUser.getLhmobjectid(), List.of(addedUser)));
-      shouldBeNull.ifPresent(users -> log.warn("User '{}' already exists.", users.stream().map(User::getLhmobjectid).toList()));
+        SimpleZammadUserFactory simpleBuilder = new SimpleZammadUserFactory(this.zammadProperties);
+        var newUser = simpleBuilder.mapToZammadUser(activeDirectoryUser, Optional.empty());
+        newUser.getRoleIds().add(roleId);
+        SimpleZammadUserFactory.activate(newUser);
+        var addedUser = zammadService.createZammadUser(newUser);
+        log.debug("New user '{}' with zammad id '{}' added.", addedUser.getLhmobjectid(), addedUser.getId());
+        var shouldBeNull = Optional.ofNullable(zammadUsers.putIfAbsent(addedUser.getLhmobjectid(), List.of(addedUser)));
+        shouldBeNull.ifPresent(
+                users -> log.warn("User '{}' already exists.", users.stream().map(User::getLhmobjectid).toList()));
 
     }
 
     protected CharSequence groupNamePrefixNullCheck() {
-        return activeDirectoryProperties.getGroupNamePrefix() != null ? activeDirectoryProperties.getGroupNamePrefix() : "";
+        return activeDirectoryProperties.getGroupNamePrefix() != null ? activeDirectoryProperties.getGroupNamePrefix()
+                : "";
     }
-
 
 }

--- a/src/main/java/de/muenchen/zammad/domain/User.java
+++ b/src/main/java/de/muenchen/zammad/domain/User.java
@@ -29,7 +29,6 @@ public class User {
     private String department;
     @EqualsAndHashCode.Include
     private String lhmobjectid;
-    @EqualsAndHashCode.Include
     @JsonProperty("role_ids")
     private List<Integer> roleIds;
     @JsonProperty("group_ids")

--- a/src/main/java/de/muenchen/zammad/ldap/branch/AbstractTree.java
+++ b/src/main/java/de/muenchen/zammad/ldap/branch/AbstractTree.java
@@ -5,13 +5,9 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import de.muenchen.zammad.domain.Group;
-import de.muenchen.zammad.domain.User;
 import de.muenchen.zammad.property.ZammadProperties;
 
 public class AbstractTree {
-
-    protected Map<String, List<Group>> zammadGroupsByLhmObjectId;
-    protected Map<String, List<User>> zammadUsersByLhmObjectId;
 
     protected ZammadService zammadService;
     protected ZammadProperties zammadProperties;

--- a/src/main/java/de/muenchen/zammad/ldap/branch/EliminatedLdapUser.java
+++ b/src/main/java/de/muenchen/zammad/ldap/branch/EliminatedLdapUser.java
@@ -102,9 +102,7 @@ public class EliminatedLdapUser extends AbstractTree {
         if (zammadGroups.isEmpty())
             return new HashMap<>();
         else {
-
-            findChildGroups(zammadService.getZammadGroups(), zammadGroups.get(0).getId(), zammadGroups);
-
+            findChildGroups(zammadService.getZammadCache().flatMapGroupsByLhmObjectId(), zammadGroups.get(0).getId(), zammadGroups);
             final var zammadBranchUsers = new ArrayList<User>();
             final var zammadUsers =  zammadService.getZammadCache().flatMapUsersByLhmObjectId();
             zammadGroups.forEach(g -> zammadBranchUsers.addAll(findUsers(zammadUsers, g.getId())));
@@ -120,7 +118,7 @@ public class EliminatedLdapUser extends AbstractTree {
 
     private List<Group> findRootZammadGroup(String ldapOuRootLhmObjectId) {
 
-        final var rootZammadGroups = getCurrentZammadGroups().get(ldapOuRootLhmObjectId);
+        final var rootZammadGroups = zammadService.getZammadCache().getZammadGroupsByLhmObjectId().get(ldapOuRootLhmObjectId);
         if (rootZammadGroups == null) {
             log.debug("No zammad root group found '{}'.", ldapOuRootLhmObjectId);
             return new ArrayList<>();

--- a/src/main/java/de/muenchen/zammad/ldap/branch/EliminatedLdapUser.java
+++ b/src/main/java/de/muenchen/zammad/ldap/branch/EliminatedLdapUser.java
@@ -104,7 +104,7 @@ public class EliminatedLdapUser extends AbstractTree {
             findChildGroups(zammadService.getZammadGroups(), zammadGroups.get(0).getId(), zammadGroups);
 
             final var zammadBranchUsers = new ArrayList<User>();
-            final var zammadUsers = zammadService.getZammadUsers();
+            final var zammadUsers =  zammadService.getZammadCache().flatMapUsersByLhmObjectId();
             zammadGroups.forEach(g -> zammadBranchUsers.addAll(findUsers(zammadUsers, g.getId())));
 
             Collections.sort(zammadBranchUsers, Comparator.comparing(User::getId));

--- a/src/main/java/de/muenchen/zammad/ldap/branch/EliminatedLdapUser.java
+++ b/src/main/java/de/muenchen/zammad/ldap/branch/EliminatedLdapUser.java
@@ -21,6 +21,8 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class EliminatedLdapUser extends AbstractTree {
 
+    public static final String DELETE = "delete";
+
     public EliminatedLdapUser(ZammadService zammadService) {
         this.zammadService = zammadService;
     }
@@ -85,7 +87,7 @@ public class EliminatedLdapUser extends AbstractTree {
                 log.debug("User in Zammad is active '{}' - setting to inactive as a first step.",
                         zammadUser.isActive());
                 zammadUser.setActive(false);
-                zammadUser.setLdapsyncstate("delete");
+                zammadUser.setLdapsyncstate(DELETE);
                 zammadService.updateZammadUser(zammadUser);
             }
         } else {

--- a/src/main/java/de/muenchen/zammad/ldap/branch/GroupAssignmentAuthorizations.java
+++ b/src/main/java/de/muenchen/zammad/ldap/branch/GroupAssignmentAuthorizations.java
@@ -30,7 +30,7 @@ public class GroupAssignmentAuthorizations {
 
      // Fetch all zammad groups
         log.debug("Getting all zammad groups");
-        zammadGroups = zammadService.getZammadGroups();
+        zammadGroups = zammadService.getZammadCache().flatMapGroupsByLhmObjectId();
 
         assignRolesTicketGroupAssignment();
         assignRolesTechnicalUser();

--- a/src/main/java/de/muenchen/zammad/ldap/branch/GroupAssignmentAuthorizations.java
+++ b/src/main/java/de/muenchen/zammad/ldap/branch/GroupAssignmentAuthorizations.java
@@ -30,7 +30,7 @@ public class GroupAssignmentAuthorizations {
 
      // Fetch all zammad groups
         log.debug("Getting all zammad groups");
-        zammadGroups = zammadService.getZammadCache().flatMapGroupsByLhmObjectId();
+        zammadGroups = zammadService.getZammadGroups();
 
         assignRolesTicketGroupAssignment();
         assignRolesTechnicalUser();

--- a/src/main/java/de/muenchen/zammad/ldap/branch/OrgUnitBranchControl.java
+++ b/src/main/java/de/muenchen/zammad/ldap/branch/OrgUnitBranchControl.java
@@ -43,41 +43,43 @@ public class OrgUnitBranchControl {
      */
     public void synchronizationControl() {
 
+        log.info("Start sychronize Zammad groups, user and roles ...");
+
         List<String> ldapDistinguishedNames = requestedOrgUnits.flatMapDistinguishedNames();
         log.info("OuBases :");
         ldapDistinguishedNames.forEach(dn -> log.info("   {}", dn));
 
-        log.info("Start sychronize Zammad groups, user and roles ...");
-
-        log.debug("1/6 Start LDAP operations ...");
+        log.info("1/5 Start LDAP operations ...");
         Map<String, LdapOuNode> ldapShadeTrees = ldapTreeService.buildLdapTrees(null, requestedOrgUnits);
 
-        log.debug("2/6 Check completeness of the requested ldap ous ...");
+        log.info("2/5 Check completeness of the requested ldap ous ...");
         dnValidation.warnIncompleteness(ldapDistinguishedNames, ldapShadeTrees);
 
+        log.info("3/5 Start process ouBases ...");
+        int ouNumber = 0;
         for (Map.Entry<String, LdapOuNode> entry : ldapShadeTrees.entrySet()) {
 
             log.info("Begin synchronize Zammad groups and users with ouBase : {}. ", entry.getKey());
 
             log.trace(entry.getValue().toString());
 
-            log.debug("3/6 Update zammad groups and users ...");
+            log.info("3/5-{} Update zammad groups and users ...", ++ouNumber);
             final var map = new HashMap<String, LdapOuNode>();
             map.put(entry.getKey(), entry.getValue());
             subtree.updateZammadGroupsWithUsers(map);
 
-            log.debug("4/6 Mark user for deletion ...");
+            log.info("3/5-{} Mark user for deletion ...", ouNumber);
             deletedLdapUser.checkForRemoval(entry,
                     Optional.ofNullable(ShadeTree.collectUserFromAllBranches(ldapShadeTrees)));
 
             log.info("End sychronize Zammad groups and users with ouBase : {}.", entry.getKey());
         }
 
-        log.info("5/6 Sync active directory groups and zammad roles ...");
+        log.info("4/5 Sync active directory groups and zammad roles ...");
         activeDirectoryRoleMapper.syncAdGroupsToLdapRoles();
 
         if (!ldapShadeTrees.isEmpty()) {
-            log.debug("6/6 Sync assignment roles for all ouBases ...");
+            log.info("5/5 Sync assignment roles for all ouBases ...");
             groupAssignmentAuthorizations.assignRoleAuthorizations();
         }
 

--- a/src/main/java/de/muenchen/zammad/ldap/branch/OrgUnitBranchSynchronization.java
+++ b/src/main/java/de/muenchen/zammad/ldap/branch/OrgUnitBranchSynchronization.java
@@ -35,8 +35,12 @@ public class OrgUnitBranchSynchronization extends AbstractTree {
     public void updateZammadGroupsWithUsers(Map<String, LdapOuNode> shadeLdapSubtree) {
 
         this.statistic = new Statistic();
-        zammadGroupsByLhmObjectId = getCurrentZammadGroups();
-        zammadUsersByLhmObjectId = getCurrentZammadUsers();
+
+        if (zammadService.getZammadCache().isEmptyZammadGroupsByLhmObjectId())
+            zammadService.getZammadCache().setZammadGroupsByLhmObjectId(getCurrentZammadGroups());
+
+         if (zammadService.getZammadCache().isEmptyZammadUsersByLhmObjectId())
+             zammadService.getZammadCache().setZammadUsersByLhmObjectId(getCurrentZammadUsers());
 
         shadeLdapSubtree.entrySet().stream().findFirst()
                 .ifPresent(finding -> statistic.logInfoStartProcessing(finding.getValue()));
@@ -64,7 +68,7 @@ public class OrgUnitBranchSynchronization extends AbstractTree {
 
                 // Find zammad group with lhmObjectID
                 final var lhmObjectIdToFind = ldapOuDto.getLhmObjectId();
-                final var zammadGroupList = zammadGroupsByLhmObjectId.get(lhmObjectIdToFind);
+                final var zammadGroupList = this.zammadService.getZammadCache().getZammadGroupsByLhmObjectId().get(lhmObjectIdToFind);
 
                 Integer currentZammadGroupId = null;
                 if (zammadGroupList != null && zammadGroupList.size() > 1) {
@@ -120,7 +124,6 @@ public class OrgUnitBranchSynchronization extends AbstractTree {
 
     private Optional<Integer> createNewZammadGroup(Group zammadGroupCompare, String lhmObjectIdToFind) {
 
-        StringBuilder zammadId = new StringBuilder();
         log.debug("Group not found in Zammad with lhmObjectId '{}' - creating.", lhmObjectIdToFind);
         // Not found: create new with isLdapsyncupdate=true
         Optional<Group> zammadGroup = zammadService.createZammadGroup(zammadGroupCompare);
@@ -172,7 +175,7 @@ public class OrgUnitBranchSynchronization extends AbstractTree {
                 log.trace(zammadUserCompare.toString());
                 // Find zammad-user with lhmObjectID
                 String lhmObjectIdToFind = user.getLhmObjectId();
-                final var foundZammadUser = Optional.ofNullable(zammadUsersByLhmObjectId.get(lhmObjectIdToFind));
+                final var foundZammadUser = Optional.ofNullable(this.zammadService.getZammadCache().getZammadUsersByLhmObjectId().get(lhmObjectIdToFind));
                 foundZammadUser.ifPresentOrElse(users ->  this.updateUsers(zammadUserCompare, users, lhmObjectIdToFind), () -> createZammadUser(zammadUserCompare, lhmObjectIdToFind));
                 log.debug(LOG_DIVIDER);
             });

--- a/src/main/java/de/muenchen/zammad/ldap/branch/OrgUnitBranchSynchronization.java
+++ b/src/main/java/de/muenchen/zammad/ldap/branch/OrgUnitBranchSynchronization.java
@@ -36,11 +36,17 @@ public class OrgUnitBranchSynchronization extends AbstractTree {
 
         this.statistic = new Statistic();
 
-        if (zammadService.getZammadCache().isEmptyZammadGroupsByLhmObjectId())
+        if (zammadService.getZammadCache().isEmptyZammadGroupsByLhmObjectId()) {
+            log.info("Start read Zammad groups ...");
             zammadService.getZammadCache().setZammadGroupsByLhmObjectId(getCurrentZammadGroups());
+            log.info("Stop read Zammad groups. '{}' groups read.", zammadService.getZammadCache().getZammadGroupsByLhmObjectId().size());
+        }
 
-         if (zammadService.getZammadCache().isEmptyZammadUsersByLhmObjectId())
+         if (zammadService.getZammadCache().isEmptyZammadUsersByLhmObjectId()) {
+             log.info("Start read Zammad users ...");
              zammadService.getZammadCache().setZammadUsersByLhmObjectId(getCurrentZammadUsers());
+             log.info("Stop read Zammad users. '{}' users read.", zammadService.getZammadCache().getZammadUsersByLhmObjectId().size());
+         }
 
         shadeLdapSubtree.entrySet().stream().findFirst()
                 .ifPresent(finding -> statistic.logInfoStartProcessing(finding.getValue()));
@@ -248,7 +254,8 @@ public class OrgUnitBranchSynchronization extends AbstractTree {
     private void prepareUserForComparison(User zammadUserCompare, User foundZammadUser) {
         zammadUserCompare.setId(foundZammadUser.getId());
         zammadUserCompare.setUpdatedAt(foundZammadUser.getUpdatedAt());
-        zammadUserCompare.setActive(foundZammadUser.isActive());
+        zammadUserCompare.setActive(true);
+        zammadUserCompare.setLdapsyncstate(null);
         zammadUserCompare.setLdapsyncupdate(true);
     }
 

--- a/src/main/java/de/muenchen/zammad/ldap/branch/SimpleZammadUserFactory.java
+++ b/src/main/java/de/muenchen/zammad/ldap/branch/SimpleZammadUserFactory.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import de.muenchen.oss.ezldap.core.LdapUserDTO;
+import de.muenchen.zammad.ad.ActiveDirectoryUserDTO;
 import de.muenchen.zammad.domain.User;
 import de.muenchen.zammad.property.ZammadProperties;
 import lombok.AllArgsConstructor;
@@ -14,6 +15,23 @@ import lombok.AllArgsConstructor;
 public class SimpleZammadUserFactory {
 
     ZammadProperties zammadProperties;
+
+
+    public User mapToZammadUser(ActiveDirectoryUserDTO activeDirectoryUserDTO, Optional<Integer> zammadGroupId) {
+
+        User zammadUser = new User(
+                activeDirectoryUserDTO.getGivenName(),
+                activeDirectoryUserDTO.getSn(),
+                activeDirectoryUserDTO.getLhmObjectId(),
+                activeDirectoryUserDTO.getMail(),
+                activeDirectoryUserDTO.getOu(),
+                activeDirectoryUserDTO.getLhmObjectId());
+
+                zammadUser.setRoleIds(defaultSynchronizationRoles());
+                zammadGroupId.ifPresent(id -> zammadUser.setGroupIds(Map.of(id.toString(), List.of("full"))));
+                return zammadUser;
+    }
+
 
     public User mapToZammadUser(LdapUserDTO ldapBaseUserDTO, Optional<Integer> zammadGroupId) {
 

--- a/src/main/java/de/muenchen/zammad/ldap/branch/ZammadCache.java
+++ b/src/main/java/de/muenchen/zammad/ldap/branch/ZammadCache.java
@@ -38,4 +38,8 @@ public class ZammadCache {
         return zammadUsersByLhmObjectId.values().stream().flatMap(List::stream).collect(Collectors.toList());
     }
 
+    public List<Group> flatMapGroupsByLhmObjectId() {
+        return zammadGroupsByLhmObjectId.values().stream().flatMap(List::stream).collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/de/muenchen/zammad/ldap/branch/ZammadCache.java
+++ b/src/main/java/de/muenchen/zammad/ldap/branch/ZammadCache.java
@@ -1,0 +1,41 @@
+package de.muenchen.zammad.ldap.branch;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import de.muenchen.zammad.domain.Group;
+import de.muenchen.zammad.domain.User;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class ZammadCache {
+
+    private Map<String, List<Group>> zammadGroupsByLhmObjectId = new HashMap<>();
+    private Map<String, List<User>> zammadUsersByLhmObjectId = new HashMap<>();
+
+    public boolean isEmptyZammadGroupsByLhmObjectId() {
+        return zammadGroupsByLhmObjectId.isEmpty();
+    }
+
+    public boolean isEmptyZammadUsersByLhmObjectId() {
+        return zammadUsersByLhmObjectId.isEmpty();
+    }
+
+    public List<Group> putGroup(Group group) {
+        return zammadGroupsByLhmObjectId.put(String.valueOf(group.getLhmobjectid()), new ArrayList<>(Arrays.asList(group)));
+    }
+
+    public List<User> putUser(User user) {
+        return zammadUsersByLhmObjectId.put(String.valueOf(user.getLhmobjectid()), new ArrayList<>(Arrays.asList(user)));
+    }
+
+    public List<User> flatMapUsersByLhmObjectId() {
+        return zammadUsersByLhmObjectId.values().stream().flatMap(List::stream).collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/de/muenchen/zammad/ldap/branch/ZammadService.java
+++ b/src/main/java/de/muenchen/zammad/ldap/branch/ZammadService.java
@@ -19,11 +19,15 @@ import de.muenchen.zammad.domain.Role;
 import de.muenchen.zammad.domain.Signatures;
 import de.muenchen.zammad.domain.User;
 import de.muenchen.zammad.property.ZammadProperties;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 @Service
 @Slf4j
 public class ZammadService {
+
+    @Getter
+    private final ZammadCache zammadCache = new ZammadCache();
 
     private static final String AUTHORIZATION = "Authorization";
 
@@ -68,6 +72,7 @@ public class ZammadService {
         ResponseEntity<Group> responseEntity = restTemplate.exchange(zammadProperties.getUrl().getBase() + zammadProperties.getUrl().getGroups() + "/" + userId, HttpMethod.PUT, requestEntity,
                 Group.class);
 
+        this.zammadCache.putGroup(responseEntity.getBody());
         return responseEntity.getBody();
     }
 
@@ -80,6 +85,7 @@ public class ZammadService {
         ResponseEntity<String> responseEntity = restTemplate.exchange(zammadProperties.getUrl().getBase() + zammadProperties.getUrl().getGroups() + "/" + id, HttpMethod.DELETE, requestEntity,
                 String.class);
 
+        this.zammadCache.getZammadGroupsByLhmObjectId().remove(responseEntity.getBody());
         return responseEntity.getBody();
     }
 
@@ -93,7 +99,10 @@ public class ZammadService {
         try {
             responseEntity = restTemplate.exchange(zammadProperties.getUrl().getBase() + zammadProperties.getUrl().getGroups(), HttpMethod.POST, requestEntity,
                 Group.class);
+
             log.trace(responseEntity.toString());
+
+            this.zammadCache.putGroup(responseEntity.getBody());
             return Optional.of(responseEntity.getBody());
 
         } catch (Exception ex)
@@ -135,6 +144,7 @@ public class ZammadService {
         ResponseEntity<User> responseEntity = restTemplate.exchange(zammadProperties.getUrl().getBase() + zammadProperties.getUrl().getUsers() + "/" + userId, HttpMethod.PUT, requestEntity,
                 User.class);
 
+        this.zammadCache.putUser(responseEntity.getBody());
         return responseEntity.getBody();
     }
 
@@ -147,6 +157,7 @@ public class ZammadService {
         ResponseEntity<User> responseEntity = restTemplate.exchange(zammadProperties.getUrl().getBase() + zammadProperties.getUrl().getUsers(), HttpMethod.POST, requestEntity,
                 User.class);
 
+        this.zammadCache.putUser(responseEntity.getBody());
         return responseEntity.getBody();
     }
 
@@ -159,6 +170,7 @@ public class ZammadService {
         ResponseEntity<String> responseEntity = restTemplate.exchange(zammadProperties.getUrl().getBase() + zammadProperties.getUrl().getUsers() + "/" + id, HttpMethod.DELETE, requestEntity,
                 String.class);
 
+        this.zammadCache.getZammadUsersByLhmObjectId().remove(responseEntity.getBody());
         return responseEntity.getBody();
     }
 

--- a/src/test/java/de/muenchen/zammad/PrepareZammadTestEnvironment.java
+++ b/src/test/java/de/muenchen/zammad/PrepareZammadTestEnvironment.java
@@ -13,6 +13,7 @@ import de.muenchen.userservice.LdapOuNode;
 import de.muenchen.zammad.domain.ChannelsEmail;
 import de.muenchen.zammad.domain.Group;
 import de.muenchen.zammad.domain.User;
+import de.muenchen.zammad.ldap.branch.ZammadCache;
 import de.muenchen.zammad.ldap.branch.ZammadService;
 import de.muenchen.zammad.property.Assignment;
 import de.muenchen.zammad.property.OrganizationalUnitsCommonProperties;
@@ -145,4 +146,21 @@ class PrepareZammadTestEnvironment extends PrepareLdapTestShadetree {
         return zammadProperties;
 	}
 
+	protected void mockUsers(ZammadService zammadService, List<User> users) {
+
+        when(zammadService.getZammadUsers()).thenReturn(users);
+        var cache = new ZammadCache();
+        users.stream().forEach(u -> cache.putUser(u));
+
+        when(zammadService.getZammadCache()).thenReturn(cache);
+    }
+
+	protected void mockGroups(ZammadService zammadService, List<Group> groups) {
+
+        when(zammadService.getZammadGroups()).thenReturn(groups);
+        var cache = new ZammadCache();
+        groups.stream().forEach(g -> cache.putGroup(g));
+
+        when(zammadService.getZammadCache()).thenReturn(cache);
+    }
 }

--- a/src/test/java/de/muenchen/zammad/PrepareZammadTestEnvironment.java
+++ b/src/test/java/de/muenchen/zammad/PrepareZammadTestEnvironment.java
@@ -29,6 +29,8 @@ class PrepareZammadTestEnvironment extends PrepareLdapTestShadetree {
     public static final String ORGANIZATIONAL_UNIT_CHANNEL = "ITM";
     public static final String STANDARD_EMAIL_CHANNEL = "LHM";
 
+    private ZammadCache cache = new ZammadCache();
+
     protected void userAndGroupMocks(ZammadService zammadService) {
         // Groups
         when(zammadService.createZammadGroup(new Group(null, null, "shortname_0_1", true, true, "lhmobjectId_0_1", null, null, null))).thenReturn(Optional.of(new Group(1, null, "shortname_0_1", true, true, "lhmobjectId_0_1", null, null, null)));
@@ -146,19 +148,18 @@ class PrepareZammadTestEnvironment extends PrepareLdapTestShadetree {
         return zammadProperties;
 	}
 
-	protected void mockUsers(ZammadService zammadService, List<User> users) {
+
+	protected void mockUsersCache(ZammadService zammadService, List<User> users) {
 
         when(zammadService.getZammadUsers()).thenReturn(users);
-        var cache = new ZammadCache();
         users.stream().forEach(u -> cache.putUser(u));
 
         when(zammadService.getZammadCache()).thenReturn(cache);
     }
 
-	protected void mockGroups(ZammadService zammadService, List<Group> groups) {
+	protected void mockGroupsCache(ZammadService zammadService, List<Group> groups) {
 
         when(zammadService.getZammadGroups()).thenReturn(groups);
-        var cache = new ZammadCache();
         groups.stream().forEach(g -> cache.putGroup(g));
 
         when(zammadService.getZammadCache()).thenReturn(cache);

--- a/src/test/java/de/muenchen/zammad/ad/ldap/ActiveDirectoryGroupsTest.java
+++ b/src/test/java/de/muenchen/zammad/ad/ldap/ActiveDirectoryGroupsTest.java
@@ -24,6 +24,7 @@ import de.muenchen.zammad.ad.ActiveDirectoryGroupService;
 import de.muenchen.zammad.ad.ldap.mediator.ActiveDirectoryGroupZammadRoleMapper;
 import de.muenchen.zammad.domain.Role;
 import de.muenchen.zammad.domain.User;
+import de.muenchen.zammad.ldap.branch.ZammadCache;
 import de.muenchen.zammad.ldap.branch.ZammadService;
 import de.muenchen.zammad.property.ActiveDirectoryProperty;
 
@@ -44,29 +45,39 @@ class ActiveDirectoryGroupsTest extends PrepareTestCrossFunctionalGroups {
 
         var zammadService = mock(ZammadService.class);
         when(zammadService.getZammadGroups()).thenReturn(List.of());
-        when(zammadService.getZammadRoles()).thenReturn(List.of(new Role(998, "rit-testrolle1-ig", null), new Role(999, "rit-testrolle2-ig", null)));
-        when(zammadService.getZammadUsers()).thenReturn(List.of(new User(2, "Tick", "Duck", "lhmObjectIdTickDuck", "ITM", "lhmObjectIdTickDuck", new ArrayList<Integer>(Arrays.asList(0,1))),
-                                                                new User(3, "Track", "Duck", "lhmObjectIdTrackDuck", "ITM", "lhmObjectIdTrackDuck", new ArrayList<Integer>(Arrays.asList(0,1)))));
+        when(zammadService.getZammadRoles()).thenReturn(
+                List.of(new Role(998, "rit-testrolle1-ig", null), new Role(999, "rit-testrolle2-ig", null)));
+
+        var users = List.of(
+                new User(2, "Tick", "Duck", "lhmObjectIdTickDuck", "ITM", "lhmObjectIdTickDuck",
+                        new ArrayList<Integer>(Arrays.asList(0, 1))),
+                new User(3, "Track", "Duck", "lhmObjectIdTrackDuck", "ITM", "lhmObjectIdTrackDuck",
+                        new ArrayList<Integer>(Arrays.asList(0, 1))));
+        mockUsers(zammadService, users);
+
         mockZammadServiceActions(zammadService);
 
         var activeDirectoryService = mock(ActiveDirectoryService.class);
         mockUserLookUps(activeDirectoryService);
 
         var activeDirectoryGroupService = mock(ActiveDirectoryGroupService.class);
-        when(activeDirectoryGroupService.crossOrganizationalGroups()).thenReturn(Optional.of(createAndUpdateZammadRolesEveryUserOnlyInOneRole()));
+        when(activeDirectoryGroupService.crossOrganizationalGroups())
+                .thenReturn(Optional.of(createAndUpdateZammadRolesEveryUserOnlyInOneRole()));
 
-        var activeDirectoryRoleMapper = new ActiveDirectoryGroupZammadRoleMapper(activeDirectoryService, createZammadProperties(), new ActiveDirectoryProperty(null, null, null,null, "lhm-ab-dbsticketing-"), activeDirectoryGroupService, zammadService);
+        var activeDirectoryRoleMapper = new ActiveDirectoryGroupZammadRoleMapper(activeDirectoryService,
+                createZammadProperties(), new ActiveDirectoryProperty(null, null, null, null, "lhm-ab-dbsticketing-"),
+                activeDirectoryGroupService, zammadService);
         activeDirectoryRoleMapper.syncAdGroupsToLdapRoles();
 
         verify(zammadService, times(1)).createZammadUser(createUserCaptor.capture());
         assertEquals("lhmObjectIdTrickDuck", createUserCaptor.getAllValues().get(0).getLhmobjectid());
-        assertEquals(List.of(0,1,998), createUserCaptor.getAllValues().get(0).getRoleIds());
+        assertEquals(List.of(0, 1, 998), createUserCaptor.getAllValues().get(0).getRoleIds());
 
         verify(zammadService, times(2)).updateZammadUser(updateUserCaptor.capture());
         assertEquals("lhmObjectIdTickDuck", updateUserCaptor.getAllValues().get(0).getLhmobjectid());
-        assertEquals(List.of(0,1,998), updateUserCaptor.getAllValues().get(0).getRoleIds());
+        assertEquals(List.of(0, 1, 998), updateUserCaptor.getAllValues().get(0).getRoleIds());
         assertEquals("lhmObjectIdTrackDuck", updateUserCaptor.getAllValues().get(1).getLhmobjectid());
-        assertEquals(List.of(0,1,999), updateUserCaptor.getAllValues().get(1).getRoleIds());
+        assertEquals(List.of(0, 1, 999), updateUserCaptor.getAllValues().get(1).getRoleIds());
 
     }
 
@@ -75,9 +86,16 @@ class ActiveDirectoryGroupsTest extends PrepareTestCrossFunctionalGroups {
 
         var zammadService = mock(ZammadService.class);
         when(zammadService.getZammadGroups()).thenReturn(List.of());
-        when(zammadService.getZammadRoles()).thenReturn(List.of(new Role(998, "rit-testrolle1-ig", null), new Role(999, "rit-testrolle2-ig", null)));
-        when(zammadService.getZammadUsers()).thenReturn(List.of(new User(2, "Tick", "Duck", "lhmObjectIdTickDuck", "ITM", "lhmObjectIdTickDuck", new ArrayList<Integer>(Arrays.asList(0,1,998))),
-                                                                new User(3, "Track", "Duck", "lhmObjectIdTrackDuck", "ITM", "lhmObjectIdTrackDuck", new ArrayList<Integer>(Arrays.asList(0,1,999)))));
+        when(zammadService.getZammadRoles()).thenReturn(
+                List.of(new Role(998, "rit-testrolle1-ig", null), new Role(999, "rit-testrolle2-ig", null)));
+
+        var users = List.of(
+                new User(2, "Tick", "Duck", "lhmObjectIdTickDuck", "ITM", "lhmObjectIdTickDuck",
+                        new ArrayList<Integer>(Arrays.asList(0, 1, 998))),
+                new User(3, "Track", "Duck", "lhmObjectIdTrackDuck", "ITM", "lhmObjectIdTrackDuck",
+                        new ArrayList<Integer>(Arrays.asList(0, 1, 999))));
+        mockUsers(zammadService, users);
+
         mockZammadServiceActions(zammadService);
 
         var activeDirectoryService = mock(ActiveDirectoryService.class);
@@ -86,18 +104,20 @@ class ActiveDirectoryGroupsTest extends PrepareTestCrossFunctionalGroups {
         var activeDirectoryGroupService = mock(ActiveDirectoryGroupService.class);
         when(activeDirectoryGroupService.crossOrganizationalGroups()).thenReturn(Optional.of(removedZammadRoleUsers()));
 
-        var activeDirectoryRoleMapper = new ActiveDirectoryGroupZammadRoleMapper(activeDirectoryService, createZammadProperties(), new ActiveDirectoryProperty(null, null, null,null, "lhm-ab-dbsticketing-"), activeDirectoryGroupService, zammadService);
+        var activeDirectoryRoleMapper = new ActiveDirectoryGroupZammadRoleMapper(activeDirectoryService,
+                createZammadProperties(), new ActiveDirectoryProperty(null, null, null, null, "lhm-ab-dbsticketing-"),
+                activeDirectoryGroupService, zammadService);
         activeDirectoryRoleMapper.syncAdGroupsToLdapRoles();
 
         verify(zammadService, times(1)).createZammadUser(createUserCaptor.capture());
         assertEquals("lhmObjectIdTrickDuck", createUserCaptor.getAllValues().get(0).getLhmobjectid());
-        assertEquals(List.of(0,1,998), createUserCaptor.getAllValues().get(0).getRoleIds());
+        assertEquals(List.of(0, 1, 998), createUserCaptor.getAllValues().get(0).getRoleIds());
 
         verify(zammadService, times(2)).updateZammadUser(updateUserCaptor.capture());
         assertEquals("lhmObjectIdTickDuck", updateUserCaptor.getAllValues().get(0).getLhmobjectid());
-        assertEquals(List.of(0,1), updateUserCaptor.getAllValues().get(0).getRoleIds());
+        assertEquals(List.of(0, 1), updateUserCaptor.getAllValues().get(0).getRoleIds());
         assertEquals("lhmObjectIdTrackDuck", updateUserCaptor.getAllValues().get(1).getLhmobjectid());
-        assertEquals(List.of(0,1), updateUserCaptor.getAllValues().get(1).getRoleIds());
+        assertEquals(List.of(0, 1), updateUserCaptor.getAllValues().get(1).getRoleIds());
 
     }
 
@@ -107,17 +127,25 @@ class ActiveDirectoryGroupsTest extends PrepareTestCrossFunctionalGroups {
         var zammadService = mock(ZammadService.class);
         when(zammadService.getZammadGroups()).thenReturn(List.of());
         when(zammadService.getZammadRoles()).thenReturn(List.of());
-        when(zammadService.getZammadUsers()).thenReturn(List.of(new User(2, "Tick", "Duck", "lhmObjectIdTickDuck", "ITM", "lhmObjectIdTickDuck", new ArrayList<Integer>(Arrays.asList(0,1))),
-                                                                new User(3, "Track", "Duck", "lhmObjectIdTrackDuck", "ITM", "lhmObjectIdTrackDuck", new ArrayList<Integer>(Arrays.asList(0,1)))));
+        var users = List.of(
+                new User(2, "Tick", "Duck", "lhmObjectIdTickDuck", "ITM", "lhmObjectIdTickDuck",
+                        new ArrayList<Integer>(Arrays.asList(0, 1))),
+                new User(3, "Track", "Duck", "lhmObjectIdTrackDuck", "ITM", "lhmObjectIdTrackDuck",
+                        new ArrayList<Integer>(Arrays.asList(0, 1))));
+
+        mockUsers(zammadService, users);
         mockZammadServiceActions(zammadService);
 
         var activeDirectoryService = mock(ActiveDirectoryService.class);
         mockUserLookUps(activeDirectoryService);
 
         var activeDirectoryGroupService = mock(ActiveDirectoryGroupService.class);
-        when(activeDirectoryGroupService.crossOrganizationalGroups()).thenReturn(Optional.of(createAndUpdateZammadRolesEveryUserOnlyInOneRole()));
+        when(activeDirectoryGroupService.crossOrganizationalGroups())
+                .thenReturn(Optional.of(createAndUpdateZammadRolesEveryUserOnlyInOneRole()));
 
-        var activeDirectoryRoleMapper = new ActiveDirectoryGroupZammadRoleMapper(activeDirectoryService, createZammadProperties(), new ActiveDirectoryProperty(null, null, null,null, "lhm-ab-dbsticketing-"), activeDirectoryGroupService, zammadService);
+        var activeDirectoryRoleMapper = new ActiveDirectoryGroupZammadRoleMapper(activeDirectoryService,
+                createZammadProperties(), new ActiveDirectoryProperty(null, null, null, null, "lhm-ab-dbsticketing-"),
+                activeDirectoryGroupService, zammadService);
         activeDirectoryRoleMapper.syncAdGroupsToLdapRoles();
 
         verify(zammadService, times(0)).createZammadUser(createUserCaptor.capture());
@@ -133,9 +161,14 @@ class ActiveDirectoryGroupsTest extends PrepareTestCrossFunctionalGroups {
 
         var zammadService = mock(ZammadService.class);
         when(zammadService.getZammadGroups()).thenReturn(List.of());
-        when(zammadService.getZammadRoles()).thenReturn(List.of(new Role(998, "rit-testrolle1-ig", null), new Role(999, "rit-testrolle2-ig", null)));
-        when(zammadService.getZammadUsers()).thenReturn(List.of(new User(2, "Tick", "Duck", "lhmObjectIdTickDuck", "ITM", "lhmObjectIdTickDuck", new ArrayList<Integer>(Arrays.asList(0,1,998))),
-                                                                new User(3, "Track", "Duck", "lhmObjectIdTrackDuck", "ITM", "lhmObjectIdTrackDuck", new ArrayList<Integer>(Arrays.asList(0,1,999)))));
+        when(zammadService.getZammadRoles()).thenReturn(
+                List.of(new Role(998, "rit-testrolle1-ig", null), new Role(999, "rit-testrolle2-ig", null)));
+        var users = List.of(
+                new User(2, "Tick", "Duck", "lhmObjectIdTickDuck", "ITM", "lhmObjectIdTickDuck",
+                        new ArrayList<Integer>(Arrays.asList(0, 1, 998))),
+                new User(3, "Track", "Duck", "lhmObjectIdTrackDuck", "ITM", "lhmObjectIdTrackDuck",
+                        new ArrayList<Integer>(Arrays.asList(0, 1, 999))));
+        mockUsers(zammadService, users);
         mockZammadServiceActions(zammadService);
 
         var activeDirectoryService = mock(ActiveDirectoryService.class);
@@ -144,7 +177,9 @@ class ActiveDirectoryGroupsTest extends PrepareTestCrossFunctionalGroups {
         var activeDirectoryGroupService = mock(ActiveDirectoryGroupService.class);
         when(activeDirectoryGroupService.crossOrganizationalGroups()).thenReturn(Optional.of(List.of()));
 
-        var activeDirectoryRoleMapper = new ActiveDirectoryGroupZammadRoleMapper(activeDirectoryService, createZammadProperties(), new ActiveDirectoryProperty(null, null, null,null, "lhm-ab-dbsticketing-"), activeDirectoryGroupService, zammadService);
+        var activeDirectoryRoleMapper = new ActiveDirectoryGroupZammadRoleMapper(activeDirectoryService,
+                createZammadProperties(), new ActiveDirectoryProperty(null, null, null, null, "lhm-ab-dbsticketing-"),
+                activeDirectoryGroupService, zammadService);
         activeDirectoryRoleMapper.syncAdGroupsToLdapRoles();
 
         verify(zammadService, times(0)).createZammadUser(createUserCaptor.capture());
@@ -152,34 +187,42 @@ class ActiveDirectoryGroupsTest extends PrepareTestCrossFunctionalGroups {
     }
 
     /*
-     * Add users not exist in ldap and are present in more than one active directory group.
+     * Add users not exist in ldap and are present in more than one active directory
+     * group.
      */
     @Test
     void userExistsInManyActiveDirectoryGroups() {
 
         var zammadService = mock(ZammadService.class);
         when(zammadService.getZammadGroups()).thenReturn(List.of());
-        when(zammadService.getZammadRoles()).thenReturn(List.of(new Role(998, "rit-testrolle1-ig", null), new Role(999, "rit-testrolle2-ig", null)));
-        when(zammadService.getZammadUsers()).thenReturn(List.of(new User(2, "Tick", "Duck", "lhmObjectIdTickDuck", "ITM", "lhmObjectIdTickDuck", new ArrayList<Integer>(Arrays.asList(0,1,998)))));
+        when(zammadService.getZammadRoles()).thenReturn(
+                List.of(new Role(998, "rit-testrolle1-ig", null), new Role(999, "rit-testrolle2-ig", null)));
+    var users = List.of(new User(2, "Tick", "Duck", "lhmObjectIdTickDuck",
+                "ITM", "lhmObjectIdTickDuck", new ArrayList<Integer>(Arrays.asList(0, 1, 998))));
 
+        mockUsers(zammadService, users);
         mockZammadServiceActions(zammadService);
 
         var activeDirectoryService = mock(ActiveDirectoryService.class);
         mockUserLookUps(activeDirectoryService);
 
         var activeDirectoryGroupService = mock(ActiveDirectoryGroupService.class);
-        when(activeDirectoryGroupService.crossOrganizationalGroups()).thenReturn(Optional.of(createAndUpdateZammadRolesUserInManyRoles()));
+        when(activeDirectoryGroupService.crossOrganizationalGroups())
+                .thenReturn(Optional.of(createAndUpdateZammadRolesUserInManyRoles()));
 
-        var activeDirectoryRoleMapper = new ActiveDirectoryGroupZammadRoleMapper(activeDirectoryService, createZammadProperties(), new ActiveDirectoryProperty(null, null, null,null, "lhm-ab-dbsticketing-"), activeDirectoryGroupService, zammadService);
+        var activeDirectoryRoleMapper = new ActiveDirectoryGroupZammadRoleMapper(activeDirectoryService,
+                createZammadProperties(), new ActiveDirectoryProperty(null, null, null, null, "lhm-ab-dbsticketing-"),
+                activeDirectoryGroupService, zammadService);
         activeDirectoryRoleMapper.syncAdGroupsToLdapRoles();
 
         verify(zammadService, times(2)).createZammadUser(createUserCaptor.capture());
-        var track = createUserCaptor.getAllValues().stream().filter(user -> user.getFirstname().equals("Track")).toList();
+        var track = createUserCaptor.getAllValues().stream().filter(user -> user.getFirstname().equals("Track"))
+                .toList();
         assertEquals("Track", track.get(0).getFirstname());
-        assertEquals(List.of(0,1,998), track.get(0).getRoleIds());
+        assertEquals(List.of(0, 1, 998), track.get(0).getRoleIds());
         verify(zammadService, times(1)).updateZammadUser(updateUserCaptor.capture());
         assertEquals("Track", updateUserCaptor.getAllValues().get(0).getFirstname());
-        assertEquals(List.of(0,1,998,999), updateUserCaptor.getAllValues().get(0).getRoleIds());
+        assertEquals(List.of(0, 1, 998, 999), updateUserCaptor.getAllValues().get(0).getRoleIds());
 
     }
 

--- a/src/test/java/de/muenchen/zammad/ad/ldap/ActiveDirectoryGroupsTest.java
+++ b/src/test/java/de/muenchen/zammad/ad/ldap/ActiveDirectoryGroupsTest.java
@@ -1,6 +1,7 @@
 package de.muenchen.zammad.ad.ldap;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -60,7 +61,7 @@ class ActiveDirectoryGroupsTest extends PrepareTestCrossFunctionalGroups {
                         new ArrayList<Integer>(Arrays.asList(0, 1))),
                 new User(3, "Track", "Duck", "lhmObjectIdTrackDuck", "ITM", "lhmObjectIdTrackDuck",
                         new ArrayList<Integer>(Arrays.asList(0, 1))));
-        mockUsers(zammadService, users);
+        mockUsersCache(zammadService, users);
 
         mockZammadServiceActions(zammadService);
 
@@ -101,7 +102,7 @@ class ActiveDirectoryGroupsTest extends PrepareTestCrossFunctionalGroups {
                         new ArrayList<Integer>(Arrays.asList(0, 1, 998))),
                 new User(3, "Track", "Duck", "lhmObjectIdTrackDuck", "ITM", "lhmObjectIdTrackDuck",
                         new ArrayList<Integer>(Arrays.asList(0, 1, 999))));
-        mockUsers(zammadService, users);
+        mockUsersCache(zammadService, users);
 
         mockZammadServiceActions(zammadService);
 
@@ -140,7 +141,7 @@ class ActiveDirectoryGroupsTest extends PrepareTestCrossFunctionalGroups {
                 new User(3, "Track", "Duck", "lhmObjectIdTrackDuck", "ITM", "lhmObjectIdTrackDuck",
                         new ArrayList<Integer>(Arrays.asList(0, 1))));
 
-        mockUsers(zammadService, users);
+        mockUsersCache(zammadService, users);
         mockZammadServiceActions(zammadService);
 
         var activeDirectoryService = mock(ActiveDirectoryService.class);
@@ -175,7 +176,7 @@ class ActiveDirectoryGroupsTest extends PrepareTestCrossFunctionalGroups {
                         new ArrayList<Integer>(Arrays.asList(0, 1, 998))),
                 new User(3, "Track", "Duck", "lhmObjectIdTrackDuck", "ITM", "lhmObjectIdTrackDuck",
                         new ArrayList<Integer>(Arrays.asList(0, 1, 999))));
-        mockUsers(zammadService, users);
+        mockUsersCache(zammadService, users);
         mockZammadServiceActions(zammadService);
 
         var activeDirectoryService = mock(ActiveDirectoryService.class);
@@ -207,7 +208,7 @@ class ActiveDirectoryGroupsTest extends PrepareTestCrossFunctionalGroups {
     var users = List.of(new User(2, "Tick", "Duck", "lhmObjectIdTickDuck",
                 "ITM", "lhmObjectIdTickDuck", new ArrayList<Integer>(Arrays.asList(0, 1, 998))));
 
-        mockUsers(zammadService, users);
+        mockUsersCache(zammadService, users);
         mockZammadServiceActions(zammadService);
 
         var activeDirectoryService = mock(ActiveDirectoryService.class);
@@ -243,11 +244,10 @@ class ActiveDirectoryGroupsTest extends PrepareTestCrossFunctionalGroups {
 
         var zammadService = mock(ZammadService.class);
         var groups = List.of(new Group(1, null, "shortname_0_1", true, true, "lhmobjectId_0_1", null, null, null));
-        mockGroups(zammadService, groups);
+        mockGroupsCache(zammadService, groups);
 
         var zammadUsers = new ArrayList<User>(Arrays.asList(new User(1, "trick", "duck", "lhmObjectIdTrickDuck", true, null, null, "lhmObjectIdTrickDuck", new ArrayList<>(Arrays.asList(0, 1)), Map.of("1", List.of("full")), null, true, null)));
-
-        mockUsers(zammadService, zammadUsers);
+        mockUsersCache(zammadService, zammadUsers);
 
         userAndGroupMocks(zammadService);
         channelsMock(zammadService);
@@ -303,7 +303,7 @@ class ActiveDirectoryGroupsTest extends PrepareTestCrossFunctionalGroups {
         var updates = updateUserCaptor.getAllValues();
         assertEquals("lhmObjectIdTrickDuck", updates.get(0).getLhmobjectid());
         assertTrue("Should be reset to activate.", updates.get(0).isActive());
-        assertTrue("Should be reset to blank", updates.get(0).getLdapsyncstate().isEmpty());
+        assertNull("Should be reset.", updates.get(0).getLdapsyncstate());
 
     }
 

--- a/src/test/java/de/muenchen/zammad/ad/ldap/ActiveDirectoryGroupsTest.java
+++ b/src/test/java/de/muenchen/zammad/ad/ldap/ActiveDirectoryGroupsTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -20,15 +19,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
-import de.muenchen.userservice.LdapService;
+import de.muenchen.userservice.ActiveDirectoryService;
 import de.muenchen.zammad.ad.ActiveDirectoryGroupService;
 import de.muenchen.zammad.ad.ldap.mediator.ActiveDirectoryGroupZammadRoleMapper;
 import de.muenchen.zammad.domain.Role;
 import de.muenchen.zammad.domain.User;
 import de.muenchen.zammad.ldap.branch.ZammadService;
 import de.muenchen.zammad.property.ActiveDirectoryProperty;
-import de.muenchen.zammad.property.OrganizationalUnitProperties;
-import de.muenchen.zammad.property.RequestedOrganizationalUnits;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -52,13 +49,13 @@ class ActiveDirectoryGroupsTest extends PrepareTestCrossFunctionalGroups {
                                                                 new User(3, "Track", "Duck", "lhmObjectIdTrackDuck", "ITM", "lhmObjectIdTrackDuck", new ArrayList<Integer>(Arrays.asList(0,1)))));
         mockZammadServiceActions(zammadService);
 
-        var ldapService = mock(LdapService.class);
-        mockUserLookUps(ldapService);
+        var activeDirectoryService = mock(ActiveDirectoryService.class);
+        mockUserLookUps(activeDirectoryService);
 
         var activeDirectoryGroupService = mock(ActiveDirectoryGroupService.class);
         when(activeDirectoryGroupService.crossOrganizationalGroups()).thenReturn(Optional.of(createAndUpdateZammadRolesEveryUserOnlyInOneRole()));
 
-        var activeDirectoryRoleMapper = new ActiveDirectoryGroupZammadRoleMapper(ldapService, createZammadProperties(), new ActiveDirectoryProperty(null, null, null,null, "lhm-ab-dbsticketing-"), activeDirectoryGroupService, zammadService, new RequestedOrganizationalUnits(Map.of("ITM", new OrganizationalUnitProperties(null, LDAP_USER_SEARCH_BASE, null))));
+        var activeDirectoryRoleMapper = new ActiveDirectoryGroupZammadRoleMapper(activeDirectoryService, createZammadProperties(), new ActiveDirectoryProperty(null, null, null,null, "lhm-ab-dbsticketing-"), activeDirectoryGroupService, zammadService);
         activeDirectoryRoleMapper.syncAdGroupsToLdapRoles();
 
         verify(zammadService, times(1)).createZammadUser(createUserCaptor.capture());
@@ -83,13 +80,13 @@ class ActiveDirectoryGroupsTest extends PrepareTestCrossFunctionalGroups {
                                                                 new User(3, "Track", "Duck", "lhmObjectIdTrackDuck", "ITM", "lhmObjectIdTrackDuck", new ArrayList<Integer>(Arrays.asList(0,1,999)))));
         mockZammadServiceActions(zammadService);
 
-        var ldapService = mock(LdapService.class);
-        mockUserLookUps(ldapService);
+        var activeDirectoryService = mock(ActiveDirectoryService.class);
+        mockUserLookUps(activeDirectoryService);
 
         var activeDirectoryGroupService = mock(ActiveDirectoryGroupService.class);
         when(activeDirectoryGroupService.crossOrganizationalGroups()).thenReturn(Optional.of(removedZammadRoleUsers()));
 
-        var activeDirectoryRoleMapper = new ActiveDirectoryGroupZammadRoleMapper(ldapService, createZammadProperties(), new ActiveDirectoryProperty(null, null, null,null, "lhm-ab-dbsticketing-"), activeDirectoryGroupService, zammadService, new RequestedOrganizationalUnits(Map.of("ITM", new OrganizationalUnitProperties(null, LDAP_USER_SEARCH_BASE, null))));
+        var activeDirectoryRoleMapper = new ActiveDirectoryGroupZammadRoleMapper(activeDirectoryService, createZammadProperties(), new ActiveDirectoryProperty(null, null, null,null, "lhm-ab-dbsticketing-"), activeDirectoryGroupService, zammadService);
         activeDirectoryRoleMapper.syncAdGroupsToLdapRoles();
 
         verify(zammadService, times(1)).createZammadUser(createUserCaptor.capture());
@@ -114,13 +111,13 @@ class ActiveDirectoryGroupsTest extends PrepareTestCrossFunctionalGroups {
                                                                 new User(3, "Track", "Duck", "lhmObjectIdTrackDuck", "ITM", "lhmObjectIdTrackDuck", new ArrayList<Integer>(Arrays.asList(0,1)))));
         mockZammadServiceActions(zammadService);
 
-        var ldapService = mock(LdapService.class);
-        mockUserLookUps(ldapService);
+        var activeDirectoryService = mock(ActiveDirectoryService.class);
+        mockUserLookUps(activeDirectoryService);
 
         var activeDirectoryGroupService = mock(ActiveDirectoryGroupService.class);
         when(activeDirectoryGroupService.crossOrganizationalGroups()).thenReturn(Optional.of(createAndUpdateZammadRolesEveryUserOnlyInOneRole()));
 
-        var activeDirectoryRoleMapper = new ActiveDirectoryGroupZammadRoleMapper(ldapService, createZammadProperties(), new ActiveDirectoryProperty(null, null, null,null, "lhm-ab-dbsticketing-"), activeDirectoryGroupService, zammadService, new RequestedOrganizationalUnits(Map.of("ITM", new OrganizationalUnitProperties(null, LDAP_USER_SEARCH_BASE, null))));
+        var activeDirectoryRoleMapper = new ActiveDirectoryGroupZammadRoleMapper(activeDirectoryService, createZammadProperties(), new ActiveDirectoryProperty(null, null, null,null, "lhm-ab-dbsticketing-"), activeDirectoryGroupService, zammadService);
         activeDirectoryRoleMapper.syncAdGroupsToLdapRoles();
 
         verify(zammadService, times(0)).createZammadUser(createUserCaptor.capture());
@@ -141,13 +138,13 @@ class ActiveDirectoryGroupsTest extends PrepareTestCrossFunctionalGroups {
                                                                 new User(3, "Track", "Duck", "lhmObjectIdTrackDuck", "ITM", "lhmObjectIdTrackDuck", new ArrayList<Integer>(Arrays.asList(0,1,999)))));
         mockZammadServiceActions(zammadService);
 
-        var ldapService = mock(LdapService.class);
-        mockUserLookUps(ldapService);
+        var activeDirectoryService = mock(ActiveDirectoryService.class);
+        mockUserLookUps(activeDirectoryService);
 
         var activeDirectoryGroupService = mock(ActiveDirectoryGroupService.class);
         when(activeDirectoryGroupService.crossOrganizationalGroups()).thenReturn(Optional.of(List.of()));
 
-        var activeDirectoryRoleMapper = new ActiveDirectoryGroupZammadRoleMapper(ldapService, createZammadProperties(), new ActiveDirectoryProperty(null, null, null,null, "lhm-ab-dbsticketing-"), activeDirectoryGroupService, zammadService, new RequestedOrganizationalUnits(Map.of("ITM", new OrganizationalUnitProperties(null, LDAP_USER_SEARCH_BASE, null))));
+        var activeDirectoryRoleMapper = new ActiveDirectoryGroupZammadRoleMapper(activeDirectoryService, createZammadProperties(), new ActiveDirectoryProperty(null, null, null,null, "lhm-ab-dbsticketing-"), activeDirectoryGroupService, zammadService);
         activeDirectoryRoleMapper.syncAdGroupsToLdapRoles();
 
         verify(zammadService, times(0)).createZammadUser(createUserCaptor.capture());
@@ -167,13 +164,13 @@ class ActiveDirectoryGroupsTest extends PrepareTestCrossFunctionalGroups {
 
         mockZammadServiceActions(zammadService);
 
-        var ldapService = mock(LdapService.class);
-        mockUserLookUps(ldapService);
+        var activeDirectoryService = mock(ActiveDirectoryService.class);
+        mockUserLookUps(activeDirectoryService);
 
         var activeDirectoryGroupService = mock(ActiveDirectoryGroupService.class);
         when(activeDirectoryGroupService.crossOrganizationalGroups()).thenReturn(Optional.of(createAndUpdateZammadRolesUserInManyRoles()));
 
-        var activeDirectoryRoleMapper = new ActiveDirectoryGroupZammadRoleMapper(ldapService, createZammadProperties(), new ActiveDirectoryProperty(null, null, null,null, "lhm-ab-dbsticketing-"), activeDirectoryGroupService, zammadService, new RequestedOrganizationalUnits(Map.of("ITM", new OrganizationalUnitProperties(null, LDAP_USER_SEARCH_BASE, null))));
+        var activeDirectoryRoleMapper = new ActiveDirectoryGroupZammadRoleMapper(activeDirectoryService, createZammadProperties(), new ActiveDirectoryProperty(null, null, null,null, "lhm-ab-dbsticketing-"), activeDirectoryGroupService, zammadService);
         activeDirectoryRoleMapper.syncAdGroupsToLdapRoles();
 
         verify(zammadService, times(2)).createZammadUser(createUserCaptor.capture());

--- a/src/test/java/de/muenchen/zammad/ad/ldap/ActiveDirectoryGroupsTest.java
+++ b/src/test/java/de/muenchen/zammad/ad/ldap/ActiveDirectoryGroupsTest.java
@@ -1,5 +1,7 @@
 package de.muenchen.zammad.ad.ldap;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -9,6 +11,7 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -20,11 +23,15 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import de.muenchen.userservice.ActiveDirectoryService;
+import de.muenchen.userservice.ShadeTree;
 import de.muenchen.zammad.ad.ActiveDirectoryGroupService;
+import de.muenchen.zammad.ad.ActiveDirectoryUserDTO;
+import de.muenchen.zammad.ad.EnhancedActiveDirectoryGroupDTO;
 import de.muenchen.zammad.ad.ldap.mediator.ActiveDirectoryGroupZammadRoleMapper;
+import de.muenchen.zammad.domain.Group;
 import de.muenchen.zammad.domain.Role;
 import de.muenchen.zammad.domain.User;
-import de.muenchen.zammad.ldap.branch.ZammadCache;
+import de.muenchen.zammad.ldap.branch.EliminatedLdapUser;
 import de.muenchen.zammad.ldap.branch.ZammadService;
 import de.muenchen.zammad.property.ActiveDirectoryProperty;
 
@@ -223,6 +230,80 @@ class ActiveDirectoryGroupsTest extends PrepareTestCrossFunctionalGroups {
         verify(zammadService, times(1)).updateZammadUser(updateUserCaptor.capture());
         assertEquals("Track", updateUserCaptor.getAllValues().get(0).getFirstname());
         assertEquals(List.of(0, 1, 998, 999), updateUserCaptor.getAllValues().get(0).getRoleIds());
+
+    }
+
+    /*
+     * User is deactivated because they left their ldap organization unit and then reactivated through an active directory role.
+     */
+     @Test
+    void deactivationResetByActiveDirectorRoleTest() {
+
+        // Deactivate by ldap
+
+        var zammadService = mock(ZammadService.class);
+        var groups = List.of(new Group(1, null, "shortname_0_1", true, true, "lhmobjectId_0_1", null, null, null));
+        mockGroups(zammadService, groups);
+
+        var zammadUsers = new ArrayList<User>(Arrays.asList(new User(1, "trick", "duck", "lhmObjectIdTrickDuck", true, null, null, "lhmObjectIdTrickDuck", new ArrayList<>(Arrays.asList(0, 1)), Map.of("1", List.of("full")), null, true, null)));
+
+        mockUsers(zammadService, zammadUsers);
+
+        userAndGroupMocks(zammadService);
+        channelsMock(zammadService);
+
+        assertEquals(1, zammadService.getZammadGroups().size());
+        assertEquals(1, zammadService.getZammadUsers().size());
+
+        var deletedLdapUser = new EliminatedLdapUser(zammadService);
+
+        var reducedLdapTree = reducedLdapTree();
+        var rootNode = reducedLdapTree.entrySet().iterator().next().getValue();
+
+        assertEquals(17, rootNode.flatListLdapUserDTO().size());
+
+        var reducedEnhancedLdapUserDTO = ShadeTree.collectUserFromAllBranches(reducedLdapTree);
+
+        deletedLdapUser.checkForRemoval(Map.of(rootNode.getDistinguishedName(), rootNode).entrySet().iterator().next(), Optional.of(reducedEnhancedLdapUserDTO));
+
+        verify(zammadService, times(1)).updateZammadUser(updateUserCaptor.capture());
+        assertEquals("delete", updateUserCaptor.getAllValues().get(0).getLdapsyncstate());
+        assertFalse(updateUserCaptor.getAllValues().get(0).isActive());
+
+        // Activate by active directory
+
+        var activeDirectoryService = mock(ActiveDirectoryService.class);
+        mockUserLookUps(activeDirectoryService);
+
+        when(zammadService.getZammadRoles()).thenReturn(new ArrayList<>(Arrays.asList(new Role(998, "rit-testrolle1-ig", null), new Role(999, "rit-testrolle2-ig", null))));
+
+        var activeDirectoryGroupService = mock(ActiveDirectoryGroupService.class);
+
+        var adRole = new ArrayList<>(Arrays.asList(new EnhancedActiveDirectoryGroupDTO("lhm-ab-dbsticketing-rit-testrolle1-ig",
+                "lhm-ab-dbsticketing-rit-testrolle1-ig",
+                "CN=lhm-ab-dbsticketing-rit-testrolle1-ig,OU=f,OU=d,OU=c,DC=b,DC=a",
+                "lhm-ab-dbsticketing-rit-testrolle1-ig",
+                List.of(activeDirectoryUsers.get("tick.duck"),
+                        activeDirectoryUsers.get("trick.duck")),
+                Map.of("lhmObjectIdTrickDuck",
+                        new ActiveDirectoryUserDTO("trick.duck", "lhmObjectIdTrickDuck",
+                                activeDirectoryUsers.get("trick.duck"),
+                                "Trick Duck", "trick.duck", "trick.duck", "Trick", "Duck", "mail@", "ou")))));
+
+        when(activeDirectoryGroupService.crossOrganizationalGroups())
+                .thenReturn(Optional.of(adRole));
+
+        var activeDirectoryRoleMapper = new ActiveDirectoryGroupZammadRoleMapper(activeDirectoryService,
+                createZammadProperties(), new ActiveDirectoryProperty(null, null, null, null, "lhm-ab-dbsticketing-"),
+                activeDirectoryGroupService, zammadService);
+
+        activeDirectoryRoleMapper.syncAdGroupsToLdapRoles();
+
+        verify(zammadService, times(2)).updateZammadUser(updateUserCaptor.capture());
+        var updates = updateUserCaptor.getAllValues();
+        assertEquals("lhmObjectIdTrickDuck", updates.get(0).getLhmobjectid());
+        assertTrue("Should be reset to activate.", updates.get(0).isActive());
+        assertTrue("Should be reset to blank", updates.get(0).getLdapsyncstate().isEmpty());
 
     }
 

--- a/src/test/java/de/muenchen/zammad/ad/ldap/PrepareTestCrossFunctionalGroups.java
+++ b/src/test/java/de/muenchen/zammad/ad/ldap/PrepareTestCrossFunctionalGroups.java
@@ -6,11 +6,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
-import de.muenchen.oss.ezldap.core.EnhancedLdapUserDTO;
-import de.muenchen.oss.ezldap.core.LdapBaseUserDTO;
-import de.muenchen.userservice.LdapService;
+import de.muenchen.userservice.ActiveDirectoryService;
 import de.muenchen.zammad.PrepareZammadTestEnvironment;
 import de.muenchen.zammad.ad.ActiveDirectoryUserDTO;
 import de.muenchen.zammad.ad.EnhancedActiveDirectoryGroupDTO;
@@ -32,11 +29,11 @@ public abstract class PrepareTestCrossFunctionalGroups extends PrepareZammadTest
                 Map.of("lhmObjectIdTrickDuck",
                         new ActiveDirectoryUserDTO("trick.duck", "lhmObjectIdTrickDuck",
                                 activeDirectoryUsers.get("trick.duck"),
-                                "Trick Duck", "trick.duck", "trick.duck", "ITM"),
+                                "Trick Duck", "trick.duck", "trick.duck", "Trick", "Duck", "mail@", "ou"),
                         "lhmObjectIdTickDuck",
                         new ActiveDirectoryUserDTO("tick.duck", "lhmObjectIdTickDuck",
                                 activeDirectoryUsers.get("tick.duck"), "Tick Duck",
-                                "tick.duck", "tick.duck", "ITM"))),
+                                "tick.duck", "tick.duck", "Tick", "Duck", "mail@", "ou"))),
                 new EnhancedActiveDirectoryGroupDTO("lhm-ab-dbsticketing-rit-testrolle2-ig",
                         "lhm-ab-dbsticketing-rit-testrolle2-ig",
                         "CN=lhm-ab-dbsticketing-rit-testrolle2-ig,OU=f,OU=d,OU=c,DC=b,DC=a",
@@ -45,7 +42,7 @@ public abstract class PrepareTestCrossFunctionalGroups extends PrepareZammadTest
                         Map.of("lhmObjectIdTrackDuck",
                                 new ActiveDirectoryUserDTO("track.duck", "lhmObjectIdTrackDuck",
                                         activeDirectoryUsers.get("track.duck"),
-                                        "Track Duck", "track.duck", "track.duck", "ITM"))));
+                                        "Track Duck", "track.duck", "track.duck", "Track", "Duck", "mail@", "ou"))));
     }
 
     protected List<EnhancedActiveDirectoryGroupDTO> createAndUpdateZammadRolesUserInManyRoles() {
@@ -60,15 +57,15 @@ public abstract class PrepareTestCrossFunctionalGroups extends PrepareZammadTest
                 Map.of("lhmObjectIdTrickDuck",
                         new ActiveDirectoryUserDTO("trick.duck", "lhmObjectIdTrickDuck",
                                 activeDirectoryUsers.get("trick.duck"),
-                                "Trick Duck", "trick.duck", "trick.duck", "ITM"),
+                                "Trick Duck", "trick.duck", "trick.duck", "Trick", "Duck", "mail@", "ou"),
                         "lhmObjectIdTickDuck",
                         new ActiveDirectoryUserDTO("tick.duck", "lhmObjectIdTickDuck",
                                 activeDirectoryUsers.get("tick.duck"), "Tick Duck",
-                                "tick.duck", "tick.duck", "ITM"),
+                                "tick.duck", "tick.duck", "Tick", "Duck", "mail@", "ou"),
                         "lhmObjectIdTrackDuck",
                         new ActiveDirectoryUserDTO("track.duck", "lhmObjectIdTrackDuck",
                                 activeDirectoryUsers.get("track.duck"),
-                                "Track Duck", "track.duck", "track.duck", "ITM"))),
+                                "Track Duck", "track.duck", "track.duck", "Track", "Duck", "mail@", "ou"))),
                 new EnhancedActiveDirectoryGroupDTO("lhm-ab-dbsticketing-rit-testrolle2-ig",
                         "lhm-ab-dbsticketing-rit-testrolle2-ig",
                         "CN=lhm-ab-dbsticketing-rit-testrolle2-ig,OU=f,OU=d,OU=c,DC=b,DC=a",
@@ -77,7 +74,7 @@ public abstract class PrepareTestCrossFunctionalGroups extends PrepareZammadTest
                         Map.of("lhmObjectIdTrackDuck",
                                 new ActiveDirectoryUserDTO("track.duck", "lhmObjectIdTrackDuck",
                                         activeDirectoryUsers.get("track.duck"),
-                                        "Track Duck", "track.duck", "track.duck", "ITM"))));
+                                        "Track Duck", "track.duck", "track.duck", "Track", "Duck", "mail@", "ou"))));
     }
 
     protected List<EnhancedActiveDirectoryGroupDTO> removedZammadRoleUsers() {
@@ -90,7 +87,7 @@ public abstract class PrepareTestCrossFunctionalGroups extends PrepareZammadTest
                 Map.of("lhmObjectIdTrickDuck",
                         new ActiveDirectoryUserDTO("trick.duck", "lhmObjectIdTrickDuck",
                                 activeDirectoryUsers.get("trick.duck"),
-                                "Trick Duck", "trick.duck", "trick.duck", "ITM"))),
+                                "Trick Duck", "trick.duck", "trick.duck", "Trick", "Duck", "mail@", "ou"))),
         new EnhancedActiveDirectoryGroupDTO("lhm-ab-dbsticketing-rit-testrolle2-ig",
                 "lhm-ab-dbsticketing-rit-testrolle2-ig",
                 "CN=lhm-ab-dbsticketing-rit-testrolle2-ig,OU=f,OU=d,OU=c,DC=b,DC=a",
@@ -99,18 +96,18 @@ public abstract class PrepareTestCrossFunctionalGroups extends PrepareZammadTest
                 Map.of()));
     }
 
-    protected void mockUserLookUps(LdapService ldapService) {
+    protected void mockUserLookUps(ActiveDirectoryService activeDirectoryService) {
 
-        when(ldapService.lookupUser("uid=tick.duck,".concat(ActiveDirectoryGroupsTest.LDAP_USER_SEARCH_BASE))).thenReturn(Optional.of(new EnhancedLdapUserDTO(new LdapBaseUserDTO("lhmObjectIdTickDuck", null, null, "Tick", "Duck", null, null))));
-        when(ldapService.lookupUser("uid=trick.duck,".concat(ActiveDirectoryGroupsTest.LDAP_USER_SEARCH_BASE))).thenReturn(Optional.of(new EnhancedLdapUserDTO(new LdapBaseUserDTO("lhmObjectIdTrickDuck", null, null, "Trick", "Duck", null, null))));
-        when(ldapService.lookupUser("uid=track.duck,".concat(ActiveDirectoryGroupsTest.LDAP_USER_SEARCH_BASE))).thenReturn(Optional.of(new EnhancedLdapUserDTO(new LdapBaseUserDTO("lhmObjectIdTrackDuck", null, null, "Track", "Duck", null, null))));
+        when(activeDirectoryService.lookupUser("CN=tick.duck,OU=d,OU=ITM,OU=c,DC=b,DC=a")).thenReturn(new ActiveDirectoryUserDTO("cn", "lhmObjectIdTickDuck", "distinguishedName", "displayName", "name", "uid", "Ticke", "Duck", "mail", "ou"));
+        when(activeDirectoryService.lookupUser("CN=trick.duck,OU=kd,OU=ITM,OU=c,DC=b,DC=a")).thenReturn(new ActiveDirectoryUserDTO("cn", "lhmObjectIdTrickDuck", "distinguishedName", "displayName", "name", "uid", "Trick", "Duck", "mail", "ou"));
+        when(activeDirectoryService.lookupUser("CN=track.duck,OU=d,OU=ITM,OU=c,DC=bn,DC=a")).thenReturn(new ActiveDirectoryUserDTO("cn", "lhmObjectIdTrackDuck", "distinguishedName", "displayName", "name", "uid", "Track", "Duck", "mail", "ou"));
 
     }
 
     protected void mockZammadServiceActions(ZammadService zammadService) {
 
-        when(zammadService.createZammadUser(new User(null, "Trick", "Duck", "lhmObjectIdTrickDuck", true, null, null, "lhmObjectIdTrickDuck", new ArrayList<Integer>(Arrays.asList(0, 1, 998)), null, null, true, null))).thenReturn(new User(1, "Trick", "Duck", "lhmObjectIdTrickDuck", true, null, null, "lhmObjectIdTrickDuck", new ArrayList<Integer>(Arrays.asList(0, 1, 998)), null, null, true, null));
-        when(zammadService.createZammadUser(new User(null, "Track", "Duck", "lhmObjectIdTrackDuck", true, null, null, "lhmObjectIdTrackDuck", new ArrayList<Integer>(Arrays.asList(0, 1, 998)), null, null, true, null))).thenReturn(new User(3, "Track", "Duck", "lhmObjectIdTrackDuck", true, null, null, "lhmObjectIdTrackDuck", new ArrayList<Integer>(Arrays.asList(0, 1, 998)), null, null, true, null));
+        when(zammadService.createZammadUser(new User(null, "Trick", "Duck", "lhmObjectIdTrickDuck", true, "mail", "ou", "lhmObjectIdTrickDuck", new ArrayList<Integer>(Arrays.asList(0, 1, 998)), null, null, true, null))).thenReturn(new User(1, "Trick", "Duck", "lhmObjectIdTrickDuck", true, "mail", "ou", "lhmObjectIdTrickDuck", new ArrayList<Integer>(Arrays.asList(0, 1, 998)), null, null, true, null));
+        when(zammadService.createZammadUser(new User(null, "Track", "Duck", "lhmObjectIdTrackDuck", true, "mail", "ou", "lhmObjectIdTrackDuck", new ArrayList<Integer>(Arrays.asList(0, 1, 998)), null, null, true, null))).thenReturn(new User(3, "Track", "Duck", "lhmObjectIdTrackDuck", true, "mail", "ou", "lhmObjectIdTrackDuck", new ArrayList<Integer>(Arrays.asList(0, 1, 998)), null, null, true, null));
 
         when(zammadService.updateZammadUser(new User(2, "Tick", "Duck", "lhmObjectIdTickDuck", false, null, "ITM", "lhmObjectIdTickDuck", new ArrayList<Integer>(Arrays.asList(0, 1)), null, null, false, null))).thenReturn(new User(2, "Tick", "Duck", "lhmObjectIdTickDuck", false, null, "ITM", "lhmObjectIdTickDuck", new ArrayList<Integer>(Arrays.asList(0, 1)), null, null, false, null));
         when(zammadService.updateZammadUser(new User(3, "Track", "Duck", "lhmObjectIdTrackDuck", false, null, "ITM", "lhmObjectIdTrackDuck", new ArrayList<Integer>(Arrays.asList(0, 1)), null, null, false, null))).thenReturn(new User(3, "Track", "Duck", "lhmObjectIdTrackDuck", false, null, "ITM", "lhmObjectIdTrackDuck", new ArrayList<Integer>(Arrays.asList(0, 1)), null, null, false, null));

--- a/src/test/java/de/muenchen/zammad/ldap/branch/CreateGroupAndUserTest.java
+++ b/src/test/java/de/muenchen/zammad/ldap/branch/CreateGroupAndUserTest.java
@@ -47,7 +47,7 @@ class CreateGroupAndUserTest extends PrepareZammadTestEnvironment {
 
 		var zammadService = mock(ZammadService.class);
 		when(zammadService.getZammadGroups()).thenReturn(List.of());
-		mockUsers(zammadService, List.of());
+		mockUsersCache(zammadService, List.of());
 
         userAndGroupMocks(zammadService);
 
@@ -76,7 +76,7 @@ class CreateGroupAndUserTest extends PrepareZammadTestEnvironment {
 
         var zammadService = mock(ZammadService.class);
         when(zammadService.getZammadGroups()).thenReturn(List.of( new Group(1, 0, "shortname_2_1", true, true, "lhmobjectId_2_1", null, null, null)));
-        mockUsers(zammadService, List.of());
+        mockUsersCache(zammadService, List.of());
 
         assertEquals(1, zammadService.getZammadGroups().size());
         assertEquals(0, zammadService.getZammadUsers().size());

--- a/src/test/java/de/muenchen/zammad/ldap/branch/CreateGroupAndUserTest.java
+++ b/src/test/java/de/muenchen/zammad/ldap/branch/CreateGroupAndUserTest.java
@@ -47,9 +47,10 @@ class CreateGroupAndUserTest extends PrepareZammadTestEnvironment {
 
 		var zammadService = mock(ZammadService.class);
 		when(zammadService.getZammadGroups()).thenReturn(List.of());
-        when(zammadService.getZammadUsers()).thenReturn(List.of());
+		mockUsers(zammadService, List.of());
 
         userAndGroupMocks(zammadService);
+
         channelsMock(zammadService);
 
 		var zammadSyncServiceSubtree = new OrgUnitBranchSynchronization(zammadService, createZammadProperties(), new EmailAddressCache(zammadService, standardDefaultMock()), new SignatureCache(zammadService, standardDefaultMock()));
@@ -75,7 +76,7 @@ class CreateGroupAndUserTest extends PrepareZammadTestEnvironment {
 
         var zammadService = mock(ZammadService.class);
         when(zammadService.getZammadGroups()).thenReturn(List.of( new Group(1, 0, "shortname_2_1", true, true, "lhmobjectId_2_1", null, null, null)));
-        when(zammadService.getZammadUsers()).thenReturn(List.of());
+        mockUsers(zammadService, List.of());
 
         assertEquals(1, zammadService.getZammadGroups().size());
         assertEquals(0, zammadService.getZammadUsers().size());

--- a/src/test/java/de/muenchen/zammad/ldap/branch/CreateUpdateGroupAndUserTest.java
+++ b/src/test/java/de/muenchen/zammad/ldap/branch/CreateUpdateGroupAndUserTest.java
@@ -45,7 +45,7 @@ class CreateUpdateGroupAndUserTest extends PrepareZammadTestEnvironment {
 
 		var zammadService = mock(ZammadService.class);
 		when(zammadService.getZammadGroups()).thenReturn(List.of(zammadGroup_lhmobjectId_1_1_reset(), zammadGroup_lhmobjectId_2_2_2_reset()));
-        when(zammadService.getZammadUsers()).thenReturn(List.of(zammadUser_lhmobjectId_2_2_3_reset()));
+        mockUsers(zammadService, List.of(zammadUser_lhmobjectId_2_2_3_reset()));
 
         userAndGroupMocks(zammadService);
         channelsMock(zammadService);
@@ -85,7 +85,8 @@ class CreateUpdateGroupAndUserTest extends PrepareZammadTestEnvironment {
     void updateUserCreatedByZammadLoginTest() {
 
         var zammadService = mock(ZammadService.class);
-        when(zammadService.getZammadGroups()).thenReturn(List.of());
+
+        mockGroups(zammadService, List.of());
 
         var modifiedUserList = zammadUsers();
         modifiedUserList.remove(17);

--- a/src/test/java/de/muenchen/zammad/ldap/branch/CreateUpdateGroupAndUserTest.java
+++ b/src/test/java/de/muenchen/zammad/ldap/branch/CreateUpdateGroupAndUserTest.java
@@ -45,7 +45,7 @@ class CreateUpdateGroupAndUserTest extends PrepareZammadTestEnvironment {
 
 		var zammadService = mock(ZammadService.class);
 		when(zammadService.getZammadGroups()).thenReturn(List.of(zammadGroup_lhmobjectId_1_1_reset(), zammadGroup_lhmobjectId_2_2_2_reset()));
-        mockUsers(zammadService, List.of(zammadUser_lhmobjectId_2_2_3_reset()));
+        mockUsersCache(zammadService, List.of(zammadUser_lhmobjectId_2_2_3_reset()));
 
         userAndGroupMocks(zammadService);
         channelsMock(zammadService);
@@ -86,7 +86,7 @@ class CreateUpdateGroupAndUserTest extends PrepareZammadTestEnvironment {
 
         var zammadService = mock(ZammadService.class);
 
-        mockGroups(zammadService, List.of());
+        mockGroupsCache(zammadService, List.of());
 
         var modifiedUserList = zammadUsers();
         modifiedUserList.remove(17);

--- a/src/test/java/de/muenchen/zammad/ldap/branch/DeleteGroupAndUserTest.java
+++ b/src/test/java/de/muenchen/zammad/ldap/branch/DeleteGroupAndUserTest.java
@@ -47,8 +47,10 @@ class DeleteGroupAndUserTest extends PrepareZammadTestEnvironment {
 	void deleteOneGroupTest() {
 
 		var zammadService = mock(ZammadService.class);
-		when(zammadService.getZammadGroups()).thenReturn(List.of(new Group(1, null, "shortname_0_1", true, true, "lhmobjectId_0_1", null, null, null)));
-        when(zammadService.getZammadUsers()).thenReturn(zammadUsers());
+		var groups = List.of(new Group(1, null, "shortname_0_1", true, true, "lhmobjectId_0_1", null, null, null));
+		mockGroups(zammadService, groups);
+
+		mockUsers(zammadService, zammadUsers());
 
         userAndGroupMocks(zammadService);
         channelsMock(zammadService);
@@ -76,8 +78,8 @@ class DeleteGroupAndUserTest extends PrepareZammadTestEnvironment {
     void deleteAllGroupsTest() {
 
         var zammadService = mock(ZammadService.class);
-        when(zammadService.getZammadGroups()).thenReturn(zammadGroups());
-        when(zammadService.getZammadUsers()).thenReturn(zammadUsers());
+        mockGroups(zammadService, zammadGroups());
+        mockUsers(zammadService, zammadUsers());
 
         userAndGroupMocks(zammadService);
         channelsMock(zammadService);

--- a/src/test/java/de/muenchen/zammad/ldap/branch/DeleteGroupAndUserTest.java
+++ b/src/test/java/de/muenchen/zammad/ldap/branch/DeleteGroupAndUserTest.java
@@ -47,9 +47,9 @@ class DeleteGroupAndUserTest extends PrepareZammadTestEnvironment {
 
 		var zammadService = mock(ZammadService.class);
 		var groups = List.of(new Group(1, null, "shortname_0_1", true, true, "lhmobjectId_0_1", null, null, null));
-		mockGroups(zammadService, groups);
+		mockGroupsCache(zammadService, groups);
 
-		mockUsers(zammadService, zammadUsers());
+		mockUsersCache(zammadService, zammadUsers());
 
         userAndGroupMocks(zammadService);
         channelsMock(zammadService);
@@ -77,8 +77,8 @@ class DeleteGroupAndUserTest extends PrepareZammadTestEnvironment {
     void deleteAllGroupsTest() {
 
         var zammadService = mock(ZammadService.class);
-        mockGroups(zammadService, zammadGroups());
-        mockUsers(zammadService, zammadUsers());
+        mockGroupsCache(zammadService, zammadGroups());
+        mockUsersCache(zammadService, zammadUsers());
 
         userAndGroupMocks(zammadService);
         channelsMock(zammadService);

--- a/src/test/java/de/muenchen/zammad/ldap/branch/DeleteGroupAndUserTest.java
+++ b/src/test/java/de/muenchen/zammad/ldap/branch/DeleteGroupAndUserTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Map;
@@ -108,6 +107,5 @@ class DeleteGroupAndUserTest extends PrepareZammadTestEnvironment {
         assertEquals("vorname_1_3_3", updateUserCaptor.getAllValues().get(3).getFirstname());
 
     }
-
 
 }

--- a/src/test/java/de/muenchen/zammad/ldap/branch/UserLoginNoLhmObjectIdAndRoleTest.java
+++ b/src/test/java/de/muenchen/zammad/ldap/branch/UserLoginNoLhmObjectIdAndRoleTest.java
@@ -57,6 +57,8 @@ class UserLoginNoLhmObjectIdAndRoleTest extends PrepareZammadTestEnvironment {
         when(zammadService.getZammadUsers()).thenReturn(
                 List.of(new User(1, "vorname_0_0_1", "nachname_0_0_1", "lhmobjectId_0_0_1", true, null, null, null, List.of(8), Map.of("10", List.of("full")), null, true, null)));
 
+        when(zammadService.getZammadCache()).thenReturn(new ZammadCache());
+
         when(zammadService.getZammadChannelsEmail()).thenReturn(new ChannelsEmail(null));
         when(zammadService.getZammadEmailSignatures()).thenReturn(List.of());
 
@@ -84,8 +86,9 @@ class UserLoginNoLhmObjectIdAndRoleTest extends PrepareZammadTestEnvironment {
         var zammadService = mock(ZammadService.class);
 
         when(zammadService.getZammadGroups()).thenReturn(List.of(new Group(1, null, "shortname_0_1", true, true, "lhmobjectId_0_1", null, null, null)));
-        when(zammadService.getZammadUsers()).thenReturn(
-                List.of(new User(1, "vorname_0_0_1", "nachname_0_0_1", "lhmobjectId_0_0_1", false, null, null, null, List.of(8), Map.of("10", List.of("full")), null, true, null)));
+
+        var users = List.of(new User(1, "vorname_0_0_1", "nachname_0_0_1", "lhmobjectId_0_0_1", false, null, null, null, List.of(8), Map.of("10", List.of("full")), null, true, null));
+        mockUsers(zammadService, users);
 
         var zammadSyncService = new OrgUnitBranchSynchronization(zammadService, createZammadProperties(), new EmailAddressCache(zammadService, standardDefaultMock()), new SignatureCache(zammadService, standardDefaultMock()));
 

--- a/src/test/java/de/muenchen/zammad/ldap/branch/UserLoginNoLhmObjectIdAndRoleTest.java
+++ b/src/test/java/de/muenchen/zammad/ldap/branch/UserLoginNoLhmObjectIdAndRoleTest.java
@@ -88,7 +88,7 @@ class UserLoginNoLhmObjectIdAndRoleTest extends PrepareZammadTestEnvironment {
         when(zammadService.getZammadGroups()).thenReturn(List.of(new Group(1, null, "shortname_0_1", true, true, "lhmobjectId_0_1", null, null, null)));
 
         var users = List.of(new User(1, "vorname_0_0_1", "nachname_0_0_1", "lhmobjectId_0_0_1", false, null, null, null, List.of(8), Map.of("10", List.of("full")), null, true, null));
-        mockUsers(zammadService, users);
+        mockUsersCache(zammadService, users);
 
         var zammadSyncService = new OrgUnitBranchSynchronization(zammadService, createZammadProperties(), new EmailAddressCache(zammadService, standardDefaultMock()), new SignatureCache(zammadService, standardDefaultMock()));
 

--- a/src/test/java/de/muenchen/zammad/ldap/domain/ZammadUserDTOTest.java
+++ b/src/test/java/de/muenchen/zammad/ldap/domain/ZammadUserDTOTest.java
@@ -86,13 +86,13 @@ class ZammadUserDTOTest {
         assertNotEquals(userA.hashCode(), userB.hashCode(), "Hashcodes are equal unexpectedly");
     }
 
-    @Test
-    void testEqualsAndHashCode_RoleIds() {
-        val userA = new User(1, "John", "Doe", "john.doe", true, "john.doe@example.com", "IT", "123456", List.of(), Map.of(), "1970-01-01T00:00:00Z", false, "unsynced");
-        var userB = new User(1, "John", "Doe", "john.doe", true, "john.doe@example.com", "IT", "123456", List.of(1, 2, 3), Map.of(), "1970-01-01T00:00:00Z", false, "unsynced");
-        assertFalse(userA.equals(userB), "Objects are equal unexpectedly");
-        assertNotEquals(userA.hashCode(), userB.hashCode(), "Hashcodes are equal unexpectedly");
-    }
+//    @Test
+//    void testEqualsAndHashCode_RoleIds() {
+//        val userA = new User(1, "John", "Doe", "john.doe", true, "john.doe@example.com", "IT", "123456", List.of(), Map.of(), "1970-01-01T00:00:00Z", false, "unsynced");
+//        var userB = new User(1, "John", "Doe", "john.doe", true, "john.doe@example.com", "IT", "123456", List.of(1, 2, 3), Map.of(), "1970-01-01T00:00:00Z", false, "unsynced");
+//        assertFalse(userA.equals(userB), "Objects are equal unexpectedly");
+//        assertNotEquals(userA.hashCode(), userB.hashCode(), "Hashcodes are equal unexpectedly");
+//    }
 
     @Test
     void testEqualsAndHashCode_GroupIds() {

--- a/src/test/java/de/muenchen/zammad/ldap/domain/ZammadUserDTOTest.java
+++ b/src/test/java/de/muenchen/zammad/ldap/domain/ZammadUserDTOTest.java
@@ -86,14 +86,6 @@ class ZammadUserDTOTest {
         assertNotEquals(userA.hashCode(), userB.hashCode(), "Hashcodes are equal unexpectedly");
     }
 
-//    @Test
-//    void testEqualsAndHashCode_RoleIds() {
-//        val userA = new User(1, "John", "Doe", "john.doe", true, "john.doe@example.com", "IT", "123456", List.of(), Map.of(), "1970-01-01T00:00:00Z", false, "unsynced");
-//        var userB = new User(1, "John", "Doe", "john.doe", true, "john.doe@example.com", "IT", "123456", List.of(1, 2, 3), Map.of(), "1970-01-01T00:00:00Z", false, "unsynced");
-//        assertFalse(userA.equals(userB), "Objects are equal unexpectedly");
-//        assertNotEquals(userA.hashCode(), userB.hashCode(), "Hashcodes are equal unexpectedly");
-//    }
-
     @Test
     void testEqualsAndHashCode_GroupIds() {
         val userA = new User(1, "John", "Doe", "john.doe", true, "john.doe@example.com", "IT", "123456", List.of(), Map.of(), "1970-01-01T00:00:00Z", false, "unsynced");


### PR DESCRIPTION
**Description**

The merge request addresses three key tasks:
- The technical separation of LDAP and AD synchronization. This has already been reviewed but not yet merged due to vacation absences (https://github.com/it-at-m/zammad-ldap-sync/pull/99).
- Repeated REST requests to Zammad users and groups are reduced by a newly introduced cache.
- LDAP and AD are better synchronized, which also contributes to a reduction in Zammad REST calls.

Issues : DPKK1-474
