### PR TITLE
:sparkles: do not use dynamic mail-channels for outbound mails of gro…

### DIFF
--- a/src/main/java/de/muenchen/zammad/domain/Assets.java
+++ b/src/main/java/de/muenchen/zammad/domain/Assets.java
@@ -15,43 +15,4 @@ public class Assets {
     @JsonProperty("Channel")
     private final Map<Integer, Channel> channel;
 
-    public Integer findID(String name, String defaultName) {
-
-        if (getEmailAddress() == null || getEmailAddress().isEmpty())
-            return null;
-
-        var address = getEmailAddress().values().stream()
-                .filter(adress -> adress.getName().toLowerCase().startsWith(name.toLowerCase())).findFirst()
-                .orElse(null);
-
-        // organizational-units email
-        if (isChannelActive(address))
-            return address.getId();
-
-        // default email
-        if (defaultName != null) {
-            address = getEmailAddress().values().stream()
-                    .filter(adress -> adress.getName().toLowerCase().startsWith(defaultName.toLowerCase())).findFirst()
-                    .orElse(null);
-            if (isChannelActive(address))
-                return address.getId();
-
-        }
-        return null;
-    }
-
-    private boolean isChannelActive(EmailAddress address) {
-        if (address != null && getChannel() != null) {
-            final Integer emailAddressChannelId = address.getChannelId();
-
-            var channel = getChannel().values().stream().filter(chnl -> chnl.getId().equals(emailAddressChannelId))
-                    .findFirst().orElse(null);
-
-            if (channel != null)
-                return channel.getActive();
-
-        }
-        return false;
-    }
-
 }

--- a/src/main/java/de/muenchen/zammad/domain/ChannelsEmail.java
+++ b/src/main/java/de/muenchen/zammad/domain/ChannelsEmail.java
@@ -20,9 +20,12 @@ public class ChannelsEmail {
             return null;
 
         var address = getAssets().getEmailAddress().values().stream()
-                .filter(adress -> adress.getName().toLowerCase().startsWith(name.toLowerCase())).findFirst()
+                .filter(ad -> ad.getName() != null)
+                .filter(ad -> ad.getName().equalsIgnoreCase(name))
+                .filter(this::isChannelActive)
+                .findFirst()
                 .orElse(null);
-        if (isChannelActive(address))
+        if (address != null)
             return address.getId();
         else
             return null;

--- a/src/main/java/de/muenchen/zammad/domain/ChannelsEmail.java
+++ b/src/main/java/de/muenchen/zammad/domain/ChannelsEmail.java
@@ -10,16 +10,38 @@ public class ChannelsEmail {
     @JsonProperty("assets")
     private final Assets assets;
 
-    public Integer findEmailsAddressId(String name, String defaultName) {
+    public Integer findEmailsAddressId(String name) {
 
         if (name == null) {
             return null;
         }
 
-        if (getAssets() == null)
+        if (getAssets() == null || getAssets().getEmailAddress() == null)
             return null;
 
-         return getAssets().findID(name, defaultName);
+        var address = getAssets().getEmailAddress().values().stream()
+                .filter(adress -> adress.getName().toLowerCase().startsWith(name.toLowerCase())).findFirst()
+                .orElse(null);
+        if (isChannelActive(address))
+            return address.getId();
+        else
+            return null;
+
+    }
+
+
+    private boolean isChannelActive(EmailAddress address) {
+        if (address != null && getAssets().getChannel() != null) {
+            final Integer emailAddressChannelId = address.getChannelId();
+
+            var channel = getAssets().getChannel().values().stream().filter(chnl -> chnl.getId().equals(emailAddressChannelId))
+                    .findFirst().orElse(null);
+
+            if (channel != null)
+                return channel.getActive();
+
+        }
+        return false;
     }
 
 }

--- a/src/main/java/de/muenchen/zammad/ldap/branch/EmailAddressCache.java
+++ b/src/main/java/de/muenchen/zammad/ldap/branch/EmailAddressCache.java
@@ -14,7 +14,6 @@ import lombok.extern.slf4j.Slf4j;
 public class EmailAddressCache {
 
     private ZammadService zammadService;
-    private OrganizationalUnitsCommonProperties commonProperties;
 
     private final HashMap<String, Integer> cache = new HashMap<>();
 
@@ -34,8 +33,10 @@ public class EmailAddressCache {
             if (zammadServiceResponse == null)
                 cache.put(emailAddressName.toUpperCase(), null);
             else
-                cache.put(emailAddressName.toUpperCase(), zammadServiceResponse
-                        .findEmailsAddressId(emailAddressName, commonProperties.getMailStartsWith()));
+                cache.put(
+                        emailAddressName.toUpperCase(),
+                        zammadServiceResponse.findEmailsAddressId(emailAddressName)
+                );
 
             log.debug("EmaildAddressId account found in Zammad '{}={}' and added to cache.", emailAddressName,
                     cache.get(emailAddressName));

--- a/src/main/java/de/muenchen/zammad/ldap/branch/EmailAddressCache.java
+++ b/src/main/java/de/muenchen/zammad/ldap/branch/EmailAddressCache.java
@@ -24,17 +24,17 @@ public class EmailAddressCache {
             return null;
         }
 
-        if (cache.containsKey(emailAddressName.toUpperCase())) {
-            final var emailAddressID = cache.get(emailAddressName.toUpperCase());
+        if (cache.containsKey(emailAddressName)) {
+            final var emailAddressID = cache.get(emailAddressName);
             log.debug("Fetch emaildAddressId from cache : {}={}", emailAddressName, emailAddressID);
             return emailAddressID;
         } else {
             final var zammadServiceResponse = zammadService.getZammadChannelsEmail();
             if (zammadServiceResponse == null)
-                cache.put(emailAddressName.toUpperCase(), null);
+                cache.put(emailAddressName, null);
             else
                 cache.put(
-                        emailAddressName.toUpperCase(),
+                        emailAddressName,
                         zammadServiceResponse.findEmailsAddressId(emailAddressName)
                 );
 

--- a/src/main/java/de/muenchen/zammad/ldap/branch/OrgUnitBranchSynchronization.java
+++ b/src/main/java/de/muenchen/zammad/ldap/branch/OrgUnitBranchSynchronization.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import de.muenchen.zammad.property.OrganizationalUnitsCommonProperties;
 import org.springframework.stereotype.Component;
 
 import de.muenchen.oss.ezldap.core.EnhancedLdapOuSearchResultDTO;
@@ -22,14 +23,16 @@ public class OrgUnitBranchSynchronization extends AbstractTree {
 
     private final EmailAddressCache emailAddressCache;
     private final SignatureCache signatureCache;
+    private OrganizationalUnitsCommonProperties commonProperties;
     private Statistic statistic;
 
     public OrgUnitBranchSynchronization(ZammadService zammadService, ZammadProperties zammadProperties,
-            EmailAddressCache emailAddress, SignatureCache signature) {
+            EmailAddressCache emailAddress, SignatureCache signature, OrganizationalUnitsCommonProperties commonProperties) {
         this.zammadService = zammadService;
         this.zammadProperties = zammadProperties;
         this.emailAddressCache = emailAddress;
         this.signatureCache = signature;
+        this.commonProperties = commonProperties;
     }
 
     public void updateZammadGroupsWithUsers(Map<String, LdapOuNode> shadeLdapSubtree) {
@@ -68,7 +71,7 @@ public class OrgUnitBranchSynchronization extends AbstractTree {
                 final var ldapOuDto = node.getNode();
                 final var zammadCurrentGroupName = createGroupName(zammadGroupName, ldapOuDto);
                 final var zammadGroupCompare = mapToZammadGroup(node.getNode(), zammadCurrentGroupName, parentGroupID);
-                zammadGroupCompare.setEmailAddressId(emailAddressCache.findEmailAdressId(node.getOrganizationalUnit()));
+                zammadGroupCompare.setEmailAddressId(emailAddressCache.findEmailAdressId(commonProperties.getEmailChannelOutboundName()));
                 zammadGroupCompare.setSignatureId(signatureCache.findEmailSignatureId(node.getOrganizationalUnit()));
                 log.debug(zammadGroupCompare.toString());
 

--- a/src/main/java/de/muenchen/zammad/property/OrganizationalUnitsCommonProperties.java
+++ b/src/main/java/de/muenchen/zammad/property/OrganizationalUnitsCommonProperties.java
@@ -10,7 +10,10 @@ import lombok.Setter;
 @ConfigurationProperties(prefix = "sync.organizational-units-common")
 public class OrganizationalUnitsCommonProperties {
 
-    private String mailStartsWith;
+    /**
+     * Name of the Email Channel in Zammad used to send notifications of ticket updates to clients of a group.
+     */
+    private String emailChannelOutboundName;
     private String signatureStartsWith;
 
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,8 +10,8 @@ active-directory:
 
 sync:
   organizational-units-common:
-    mail-starts-with: Landeshauptstadt München
     signature-starts-with: LHM
+    email-channel-outbound-name: Landeshauptstadt München
   organizational-units:
     identifier-1:
       distinguished-names:

--- a/src/test/java/de/muenchen/zammad/PrepareZammadTestEnvironment.java
+++ b/src/test/java/de/muenchen/zammad/PrepareZammadTestEnvironment.java
@@ -89,14 +89,14 @@ class PrepareZammadTestEnvironment extends PrepareLdapTestShadetree {
         // Email Channel
         var channelsMock = mock(ChannelsEmail.class);
         when(zammadService.getZammadChannelsEmail()).thenReturn(channelsMock);
-        when(channelsMock.findEmailsAddressId(anyString(), anyString())).thenReturn(null);
+        when(channelsMock.findEmailsAddressId(anyString())).thenReturn(null);
         when(channelsMock.getAssets()).thenReturn(null);
     }
 
     protected OrganizationalUnitsCommonProperties standardDefaultMock() {
 
         var standardMock = mock(OrganizationalUnitsCommonProperties.class);
-        when(standardMock.getMailStartsWith()).thenReturn(STANDARD_EMAIL_CHANNEL);
+        when(standardMock.getEmailChannelOutboundName()).thenReturn(STANDARD_EMAIL_CHANNEL);
         when(standardMock.getSignatureStartsWith()).thenReturn(STANDARD_EMAIL_CHANNEL);
         return standardMock;
     }

--- a/src/test/java/de/muenchen/zammad/ldap/branch/CreateGroupAndUserTest.java
+++ b/src/test/java/de/muenchen/zammad/ldap/branch/CreateGroupAndUserTest.java
@@ -53,7 +53,7 @@ class CreateGroupAndUserTest extends PrepareZammadTestEnvironment {
 
         channelsMock(zammadService);
 
-		var zammadSyncServiceSubtree = new OrgUnitBranchSynchronization(zammadService, createZammadProperties(), new EmailAddressCache(zammadService, standardDefaultMock()), new SignatureCache(zammadService, standardDefaultMock()));
+		var zammadSyncServiceSubtree = new OrgUnitBranchSynchronization(zammadService, createZammadProperties(), new EmailAddressCache(zammadService), new SignatureCache(zammadService, standardDefaultMock()), standardDefaultMock());
 
 		zammadSyncServiceSubtree.updateZammadGroupsWithUsers(createLdapTree());
 
@@ -84,7 +84,7 @@ class CreateGroupAndUserTest extends PrepareZammadTestEnvironment {
         groupMocksCreateParentNodeTest(zammadService);
         channelsMock(zammadService);
 
-        var zammadSyncService = new OrgUnitBranchSynchronization(zammadService, createZammadProperties(), new EmailAddressCache(zammadService, standardDefaultMock()), new SignatureCache(zammadService, standardDefaultMock()));
+        var zammadSyncService = new OrgUnitBranchSynchronization(zammadService, createZammadProperties(), new EmailAddressCache(zammadService), new SignatureCache(zammadService, standardDefaultMock()), standardDefaultMock());
 
         var childTree_level_2 = new TreeMap<String, LdapOuNode>();
         var number = 1;

--- a/src/test/java/de/muenchen/zammad/ldap/branch/CreateUpdateGroupAndUserTest.java
+++ b/src/test/java/de/muenchen/zammad/ldap/branch/CreateUpdateGroupAndUserTest.java
@@ -50,7 +50,7 @@ class CreateUpdateGroupAndUserTest extends PrepareZammadTestEnvironment {
         userAndGroupMocks(zammadService);
         channelsMock(zammadService);
 
-		var zammadSyncServiceSubtree = new OrgUnitBranchSynchronization(zammadService, createZammadProperties(), new EmailAddressCache(zammadService, standardDefaultMock()), new SignatureCache(zammadService, standardDefaultMock()));
+		var zammadSyncServiceSubtree = new OrgUnitBranchSynchronization(zammadService, createZammadProperties(), new EmailAddressCache(zammadService), new SignatureCache(zammadService, standardDefaultMock()), standardDefaultMock());
 
 		var ldapTree = createLdapTree();
 
@@ -96,7 +96,7 @@ class CreateUpdateGroupAndUserTest extends PrepareZammadTestEnvironment {
         userAndGroupMocks(zammadService);
         channelsMock(zammadService);
 
-        var zammadSyncService = new OrgUnitBranchSynchronization(zammadService, createZammadProperties(), new EmailAddressCache(zammadService, standardDefaultMock()), new SignatureCache(zammadService, standardDefaultMock()));
+        var zammadSyncService = new OrgUnitBranchSynchronization(zammadService, createZammadProperties(), new EmailAddressCache(zammadService), new SignatureCache(zammadService, standardDefaultMock()), standardDefaultMock());
 
         var ldapTree = createLdapTree();
 

--- a/src/test/java/de/muenchen/zammad/ldap/branch/EmailAddressIdTest.java
+++ b/src/test/java/de/muenchen/zammad/ldap/branch/EmailAddressIdTest.java
@@ -24,37 +24,37 @@ class EmailAddressIdTest {
     @Test
     void nameIsNullTest() {
         var emailChannels = new ChannelsEmail(null);
-        assertNull(emailChannels.findEmailsAddressId(null, null));
+        assertNull(emailChannels.findEmailsAddressId( null));
     }
 
     @Test
     void notCompleteZammadResponseTest() {
         var emailChannels = new ChannelsEmail(null);
-        assertNull(emailChannels.findEmailsAddressId("FOO", "FOO"));
+        assertNull(emailChannels.findEmailsAddressId("FOO"));
 
         emailChannels = new ChannelsEmail(new Assets(null, null));
-        assertNull(emailChannels.findEmailsAddressId("FOO", null));
+        assertNull(emailChannels.findEmailsAddressId("FOO"));
 
         emailChannels = new ChannelsEmail(new Assets(Map.of(), null));
-        assertNull(emailChannels.findEmailsAddressId("FOO", "FOO"));
+        assertNull(emailChannels.findEmailsAddressId("FOO"));
     }
 
     @Test
     void nameNotFoundTest() {
         var emailChannels = new ChannelsEmail(new Assets(Map.of("5", new EmailAddress(5, null, "ITM")), null));
-        assertNull(emailChannels.findEmailsAddressId("FOO", null));
+        assertNull(emailChannels.findEmailsAddressId("FOO"));
     }
 
     @Test
     void organizationalUnitIgnoreCaseFoundTest() {
         var emailChannels = new ChannelsEmail(new Assets(Map.of("5", new EmailAddress(5, 1, "ItM"), "6", new EmailAddress(6, 2, "FOO")), Map.of(1, new Channel(1, true), 2, new Channel(2, true))));
-        assertEquals(Integer.valueOf(5), emailChannels.findEmailsAddressId("iTM", "lHM"));
+        assertEquals(Integer.valueOf(5), emailChannels.findEmailsAddressId("iTM"));
     }
 
 
     @Test
     void standardIgnoreCaseFoundTest() {
         var emailChannels = new ChannelsEmail(new Assets(Map.of("5", new EmailAddress(5, 1, "FOO"), "6", new EmailAddress(6, 2, "LhM")), Map.of(1, new Channel(1, true), 2, new Channel(2, true))));
-        assertEquals(Integer.valueOf(6), emailChannels.findEmailsAddressId("iTM", "lHM"));
+        assertEquals(Integer.valueOf(6), emailChannels.findEmailsAddressId("LhM"));
     }
 }

--- a/src/test/java/de/muenchen/zammad/ldap/branch/FindEmailChannelTest.java
+++ b/src/test/java/de/muenchen/zammad/ldap/branch/FindEmailChannelTest.java
@@ -40,7 +40,7 @@ class FindEmailChannelTest extends PrepareZammadTestEnvironment {
 
         when(zammadService.getZammadChannelsEmail()).thenReturn(new ChannelsEmail(null));
 
-        var cache = new EmailAddressCache(zammadService, standardDefaultMock());
+        var cache = new EmailAddressCache(zammadService);
 
         assertNull(cache.findEmailAdressId("Value does not matter"));
 
@@ -56,7 +56,7 @@ class FindEmailChannelTest extends PrepareZammadTestEnvironment {
 
         when(zammadService.getZammadChannelsEmail()).thenReturn(null);
 
-        var cache = new EmailAddressCache(zammadService, standardDefaultMock());
+        var cache = new EmailAddressCache(zammadService);
         assertNull(cache.findEmailAdressId("Value does not matter"));
 
         verify(zammadService, times(1)).getZammadChannelsEmail();
@@ -73,7 +73,7 @@ class FindEmailChannelTest extends PrepareZammadTestEnvironment {
         var mockChannelIsActive = mockChannelsEmailResponse(Map.of(ORGANIZATIONAL_UNIT_CHANNEL_ID, new Channel(ORGANIZATIONAL_UNIT_CHANNEL_ID, false), STANDARD_UNIT_CHANNEL_ID, new Channel(STANDARD_UNIT_CHANNEL_ID, false)));
         when(zammadService.getZammadChannelsEmail()).thenReturn(mockChannelIsActive);
 
-        var cache = new EmailAddressCache(zammadService, standardDefaultMock());
+        var cache = new EmailAddressCache(zammadService);
 
         // Only one call, first response is cached.
         assertNull(cache.findEmailAdressId(ORGANIZATIONAL_UNIT_CHANNEL));
@@ -92,7 +92,7 @@ class FindEmailChannelTest extends PrepareZammadTestEnvironment {
         var mockChannelIsActive = mockChannelsEmailResponse(Map.of(ORGANIZATIONAL_UNIT_CHANNEL_ID, new Channel(ORGANIZATIONAL_UNIT_CHANNEL_ID, true), STANDARD_UNIT_CHANNEL_ID, new Channel(STANDARD_UNIT_CHANNEL_ID, true)));
         when(zammadService.getZammadChannelsEmail()).thenReturn(mockChannelIsActive);
 
-        var cache = new EmailAddressCache(zammadService, standardDefaultMock());
+        var cache = new EmailAddressCache(zammadService);
 
         // Only one call, first response is cached.
         assertEquals(ORGANIZATIONAL_EMAIL_ID, cache.findEmailAdressId(ORGANIZATIONAL_UNIT_CHANNEL));
@@ -101,7 +101,7 @@ class FindEmailChannelTest extends PrepareZammadTestEnvironment {
     }
 
     @Test
-    void organizationalUnitChannelInactiveStandardActiveTest() {
+    void organizationalUnitChannelInactiveReturnsNullTest() {
 
         var zammadService = mock(ZammadService.class);
 
@@ -111,16 +111,16 @@ class FindEmailChannelTest extends PrepareZammadTestEnvironment {
         var mockChannelIsActive = mockChannelsEmailResponse(Map.of(ORGANIZATIONAL_UNIT_CHANNEL_ID, new Channel(ORGANIZATIONAL_UNIT_CHANNEL_ID, false), STANDARD_UNIT_CHANNEL_ID, new Channel(STANDARD_UNIT_CHANNEL_ID, true)));
         when(zammadService.getZammadChannelsEmail()).thenReturn(mockChannelIsActive);
 
-        var cache = new EmailAddressCache(zammadService, standardDefaultMock());
+        var cache = new EmailAddressCache(zammadService);
 
         // Only one call, first response is cached.
-        assertEquals(Integer.valueOf(STANDARD_EMAIL_ID), cache.findEmailAdressId(ORGANIZATIONAL_UNIT_CHANNEL));
-        assertEquals(Integer.valueOf(STANDARD_EMAIL_ID), cache.findEmailAdressId(ORGANIZATIONAL_UNIT_CHANNEL));
+        assertEquals(null, cache.findEmailAdressId(ORGANIZATIONAL_UNIT_CHANNEL));
+        assertEquals(null, cache.findEmailAdressId(ORGANIZATIONAL_UNIT_CHANNEL));
         verify(zammadService, times(1)).getZammadChannelsEmail();
     }
 
     @Test
-    void organizationalUnitNotFoundStandardEmailTest() {
+    void organizationalUnitNotFoundNullReturnTest() {
 
         var zammadService = mock(ZammadService.class);
 
@@ -130,9 +130,9 @@ class FindEmailChannelTest extends PrepareZammadTestEnvironment {
         var onlyStandardEmailChannelExists = mockChannelsEmailResponse(Map.of(ORGANIZATIONAL_UNIT_CHANNEL_ID, new Channel(STANDARD_UNIT_CHANNEL_ID, true), STANDARD_UNIT_CHANNEL_ID, new Channel(STANDARD_UNIT_CHANNEL_ID, true)));
         when(zammadService.getZammadChannelsEmail()).thenReturn(onlyStandardEmailChannelExists);
 
-        var cache = new EmailAddressCache(zammadService, standardDefaultMock());
-        assertEquals(Integer.valueOf(STANDARD_EMAIL_ID), cache.findEmailAdressId("FOO"));
-        assertEquals(Integer.valueOf(STANDARD_EMAIL_ID), cache.findEmailAdressId("FOO"));
+        var cache = new EmailAddressCache(zammadService);
+        assertEquals(null, cache.findEmailAdressId("FOO"));
+        assertEquals(null, cache.findEmailAdressId("FOO"));
         verify(zammadService, times(1)).getZammadChannelsEmail();
     }
 
@@ -146,7 +146,7 @@ class FindEmailChannelTest extends PrepareZammadTestEnvironment {
 
         when(zammadService.getZammadChannelsEmail()).thenReturn(mockChannelsEmailResponse(null));
 
-        var cache = new EmailAddressCache(zammadService, standardDefaultMock());
+        var cache = new EmailAddressCache(zammadService);
         assertNull(cache.findEmailAdressId(null));
 
         verify(zammadService, times(0)).getZammadChannelsEmail();

--- a/src/test/java/de/muenchen/zammad/ldap/branch/UserLoginNoLhmObjectIdAndRoleTest.java
+++ b/src/test/java/de/muenchen/zammad/ldap/branch/UserLoginNoLhmObjectIdAndRoleTest.java
@@ -62,7 +62,7 @@ class UserLoginNoLhmObjectIdAndRoleTest extends PrepareZammadTestEnvironment {
         when(zammadService.getZammadChannelsEmail()).thenReturn(new ChannelsEmail(null));
         when(zammadService.getZammadEmailSignatures()).thenReturn(List.of());
 
-        var zammadSyncService = new OrgUnitBranchSynchronization(zammadService, createZammadProperties(), new EmailAddressCache(zammadService, standardDefaultMock()), new SignatureCache(zammadService, standardDefaultMock()));
+        var zammadSyncService = new OrgUnitBranchSynchronization(zammadService, createZammadProperties(), new EmailAddressCache(zammadService), new SignatureCache(zammadService, standardDefaultMock()), standardDefaultMock());
 
         zammadSyncService.updateZammadGroupsWithUsers(createResetLdapTree());
 
@@ -90,7 +90,7 @@ class UserLoginNoLhmObjectIdAndRoleTest extends PrepareZammadTestEnvironment {
         var users = List.of(new User(1, "vorname_0_0_1", "nachname_0_0_1", "lhmobjectId_0_0_1", false, null, null, null, List.of(8), Map.of("10", List.of("full")), null, true, null));
         mockUsersCache(zammadService, users);
 
-        var zammadSyncService = new OrgUnitBranchSynchronization(zammadService, createZammadProperties(), new EmailAddressCache(zammadService, standardDefaultMock()), new SignatureCache(zammadService, standardDefaultMock()));
+        var zammadSyncService = new OrgUnitBranchSynchronization(zammadService, createZammadProperties(), new EmailAddressCache(zammadService), new SignatureCache(zammadService, standardDefaultMock()), standardDefaultMock());
 
         zammadSyncService.updateZammadGroupsWithUsers(createResetLdapTree());
 


### PR DESCRIPTION
…ups. instead fix outbound mails of groups to exactly one mail which is configurable by property

https://git.muenchen.de/dbs-ops/infra/-/work_items/170


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Outbound email channel selection now uses a dedicated configurable channel name (`email-channel-outbound-name`) to resolve the correct email addresses during synchronization.

* **Bug Fixes**
  * Email address lookup now returns results only for addresses that belong to an active channel, and no longer uses broader fallback matching.
  * Lookup now returns no result when required channel or address data is missing, preventing incorrect matches.
  * Updated channel selection and caching behavior to align with the new outbound channel setting.

* **Configuration**
  * Adjusted the `sync` configuration block ordering and set the default outbound email channel name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->